### PR TITLE
Fixed Phonenumber Field Format

### DIFF
--- a/server/main/settings.py
+++ b/server/main/settings.py
@@ -126,6 +126,11 @@ USE_L10N = True
 USE_TZ = True
 
 
+# Phonenumber Field Format
+PHONENUMBER_DB_FORMAT = 'NATIONAL'
+PHONENUMBER_DEFAULT_REGION = 'US'
+
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 


### PR DESCRIPTION
## Changes
1. Fixed the format for the `PhoneNumberField`.

## Purpose
The `PhoneNumberField` should output the data into a valid US phone number.

## Approach
In order to fix the `PhoneNumberField` into a valid US phone number, in the main settings, default values were set to let Django on the type of phone number.

## Testing
1. Pull changes.
2. Open up the shell -> `python manage.py shell`.
3. In the shell, create a dummy foodtruck with a phone number.
4. Quit the shell, then run the server -> `python manage.py runserver`.
5. On your browser, go to `http://localhost:8000/api/v1/foodtrucks/` and make sure your dummy foodtruck is outputted with the correct US phone number format of `+1##########`.

Closes #18 