### PR TITLE
Event REST API

### DIFF
--- a/server/event/serializers.py
+++ b/server/event/serializers.py
@@ -1,0 +1,22 @@
+from django.db.models import fields
+from rest_framework import serializers
+
+from .models import Event
+from foodtruck.models import Truck
+
+
+class EventSerializer(serializers.Serializer):
+    """
+    Serializer on the Event model.
+
+    Lookup Field: uuid.
+
+    Fields: uuid, date, start_time, end_time, and truck.
+    """
+    truck = serializers.SlugRelatedField(
+        slug_field='slug', queryset=Truck.objects.all(), many=True)
+
+    class Meta:
+        model = Event
+        lookup_field = 'uuid'
+        fields = ('uuid', 'date', 'start_time', 'end_time', 'truck',)

--- a/server/event/urls.py
+++ b/server/event/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+
+urlpatterns = [
+    path('', views.EventListAPIView.as_view()),
+    path('<uuid:uuid>', views.EventDetailAPIView.as_view()),
+]

--- a/server/event/views.py
+++ b/server/event/views.py
@@ -1,3 +1,27 @@
-from django.shortcuts import render
+from rest_framework import generics
 
-# Create your views here.
+from .models import Event
+from .serializers import EventSerializer
+
+
+class EventListAPIView(generics.ListAPIView):
+    """
+    API view to retrieve a list from the Event model.
+
+    Request Type: GET.
+    """
+    queryset = Event.objects.all().order_by('date')
+    serializer_class = EventSerializer
+
+
+class EventDetailAPIView(generics.RetrieveAPIView):
+    """
+    API view to retrieve one from the Event model based on its uuid.
+
+    Lookup Field: uuid.
+
+    Request Type: GET.
+    """
+    queryset = Event.objects.all().order_by('date')
+    lookup_field = 'uuid'
+    serializer_class = EventSerializer

--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
 
+from server.event.models import Event
+
 from .models import Product, Truck, TruckImage
+from event.serializers import EventSerializer
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -49,10 +52,10 @@ class TruckSerializer(serializers.ModelSerializer):
     """
     products = ProductSerializer(many=True, read_only=True)
     images = TruckImageSerializer(many=True, read_only=True)
-    # TO DO: Add in events fields
+    events = EventSerializer(many=True, read_only=True)
 
     class Meta:
         model = Truck
         lookup_field = 'slug'
         fields = ('uuid', 'name', 'slug', 'info', 'phone_number',
-                  'email', 'website', 'products', 'images',)
+                  'email', 'website', 'products', 'images', 'events',)

--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -1,7 +1,5 @@
 from rest_framework import serializers
 
-from server.event.models import Event
-
 from .models import Product, Truck, TruckImage
 from event.serializers import EventSerializer
 

--- a/server/main/urls.py
+++ b/server/main/urls.py
@@ -19,5 +19,6 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     # REST APIs
+    path('api/v1/events/', include('event.urls')),
     path('api/v1/foodtrucks/', include('foodtruck.urls')),
 ]


### PR DESCRIPTION
## Changes
1. Created serializers, views, and routes for the `Event` model.
2. Added events to the `Truck` serializer.
3. Routed the `event` app to the main urls.

## Purpose
There needs to be a REST API for the Event in order for the data to be sent to some client.

## Approach
The `Event` serializer has a relation to the `Truck` model (as well as the reverse due to Many-to-Many), and with its own properties, it would output a JSON of:

```
{
  "uuid": String,
  "date": String,
  "start_time": String,
  "end_time": String,
  "truck": Array
}
```

The `Event` serializer was also added to the `Truck` serializer to output its events it is going to.

Once the `Event` serializer was finished, views were created for retrieving and listing the `Event` model combined with its serializer. The only method the user can do with this is the `GET` method.

Then, URLs were wired up to the `Event` views, and lastly, the main URL was also wired up to the main `url` file.

Closes #20 