### PR TITLE
Social REST API

### DIFF
--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from .models import Product, Truck, TruckImage
 from event.serializers import EventSerializer
+from social.serializers import LikeSerializer
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -14,13 +15,14 @@ class ProductSerializer(serializers.ModelSerializer):
     reviews, and likes.
     """
     truck = serializers.CharField(source='truck.slug')
-    # TO DO: Add in reviews and likes fields
+    likes = LikeSerializer(many=True, read_only=True)
+    # TO DO: Add in reviews fields
 
     class Meta:
         model = Product
         lookup_field = 'slug'
         fields = ('uuid', 'name', 'slug', 'info', 'image',
-                  'price', 'quantity', 'is_available', 'truck',)
+                  'price', 'quantity', 'is_available', 'truck', 'likes',)
 
 
 class TruckImageSerializer(serializers.ModelSerializer):

--- a/server/main/urls.py
+++ b/server/main/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     # REST APIs
     path('api/v1/events/', include('event.urls')),
     path('api/v1/foodtrucks/', include('foodtruck.urls')),
+    path('api/v1/socials/', include('social.urls')),
 ]

--- a/server/social/serializers.py
+++ b/server/social/serializers.py
@@ -24,19 +24,19 @@ class LikeSerializer(serializers.ModelSerializer):
         fields = ('uuid', 'like', 'emoji', 'product',)
 
     def create(self, validated_data):
-        like_uuid = self.initial_data['uuid'] if 'uuid' in self.initial_data else None
-        like_emoji = self.initial_data['emoji'] if 'emoji' in self.initial_data else None
-        like_product = self.initial_data['product'] if 'product' in self.initial_data else None
+        incoming_uuid = self.initial_data['uuid'] if 'uuid' in self.initial_data else None
+        incoming_emoji = self.initial_data['emoji'] if 'emoji' in self.initial_data else None
+        incoming_product = self.initial_data['product'] if 'product' in self.initial_data else None
 
         # If the property exists from the data, proceed.
-        if like_uuid is not None:
-            like_exist = Like.objects.filter(uuid=like_uuid).first()
+        if incoming_uuid is not None:
+            like_exist = Like.objects.filter(uuid=incoming_uuid).first()
 
             # If the selected uuid exists in the Like model, proceed.
             if like_exist is not None:
                 # If the selected model fields matches both the incoming product and emoji,
                 # then increment.
-                if like_exist.product.slug == like_product and like_exist.emoji.emoji == like_emoji:
+                if like_exist.product.slug == incoming_product and like_exist.emoji.emoji == incoming_emoji:
                     like_exist.like += validated_data['like']
                     like_exist.save()
                     return like_exist
@@ -49,7 +49,7 @@ class LikeSerializer(serializers.ModelSerializer):
 
                     if len(likes_available):
                         for like_dict in likes_available:
-                            if like_dict.product.slug == like_product and like_dict.emoji.emoji == like_emoji:
+                            if like_dict.product.slug == incoming_product and like_dict.emoji.emoji == incoming_emoji:
                                 like_exist = like_dict
 
                     # If the dictionary is not empty, proceed.
@@ -59,13 +59,13 @@ class LikeSerializer(serializers.ModelSerializer):
                         return like_exist
 
         # If the incoming uuid was not provided, check on the incoming emoji and product.
-        elif like_emoji is not None and like_product is not None:
+        elif incoming_emoji is not None and incoming_product is not None:
             likes_available = Like.objects.all()
             like_exist = {}
 
             if len(likes_available):
                 for like_dict in likes_available:
-                    if like_dict.product.slug == like_product and like_dict.emoji.emoji == like_emoji:
+                    if like_dict.product.slug == incoming_product and like_dict.emoji.emoji == incoming_emoji:
                         like_exist = like_dict
 
             # If the dictionary is not empty, proceed.

--- a/server/social/serializers.py
+++ b/server/social/serializers.py
@@ -1,0 +1,55 @@
+from rest_framework import serializers
+
+from .models import Emoji, Like
+from foodtruck.models import Product
+
+
+class LikeSerializer(serializers.ModelSerializer):
+    """
+    Serializer on the Like model.
+
+    Fields: uuid, like, emoji, and product.
+
+    On the create method, it checks on two cases: If the object exists, then update
+    the like field by incrementing. Otherwise, if the object does not exist, then
+    create a new one.
+    """
+    emoji = serializers.SlugRelatedField(
+        slug_field='emoji', queryset=Emoji.objects.all())
+    product = serializers.SlugRelatedField(
+        slug_field='slug', queryset=Product.objects.all())
+
+    class Meta:
+        model = Like
+        fields = ('uuid', 'like', 'emoji', 'product',)
+
+    def create(self, validated_data):
+        like_uuid = self.initial_data['uuid'] if 'uuid' in self.initial_data else None
+
+        # If the property exists from the data, proceed.
+        if like_uuid is not None:
+            like_exist = Like.objects.filter(uuid=like_uuid).first()
+
+            # If the selected uuid exists in the Like model, then increment.
+            # Otherwise, it does not exist, then create a new one.
+            if like_exist is not None:
+                like_exist.like += validated_data['like']
+                like_exist.save()
+                return like_exist
+
+        new_like = Like.objects.create(**validated_data)
+        return new_like
+
+
+class EmojiSerializer(serializers.ModelSerializer):
+    """
+    Serializer on the Emoji model.
+
+    Lookup Field: uuid.
+
+    Fields: uuid, emoji, and name
+    """
+    class Meta:
+        model = Emoji
+        lookup_field = 'uuid'
+        fields = ('uuid', 'emoji', 'name',)

--- a/server/social/urls.py
+++ b/server/social/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from . import views
+
+
+urlpatterns = [
+    path('', views.LikeCreateAPIView.as_view()),
+    path('<uuid:uuid>', views.LikeDetailUpdateAPIView.as_view()),
+    path('emojis/', views.EmojiListAPIView.as_view()),
+    path('emojis/<uuid:uuid>', views.EmojiDetailAPIView.as_view()),
+]

--- a/server/social/views.py
+++ b/server/social/views.py
@@ -1,3 +1,52 @@
-from django.shortcuts import render
+from rest_framework import generics
 
-# Create your views here.
+from .models import Emoji, Like
+from .serializers import EmojiSerializer, LikeSerializer
+
+
+# Emoji views:
+class EmojiListAPIView(generics.ListAPIView):
+    """
+    API view to retrieve a list from the Emoji model.
+
+    Request Type: GET.
+    """
+    queryset = Emoji.objects.all()
+    serializer_class = EmojiSerializer
+
+
+class EmojiDetailAPIView(generics.RetrieveAPIView):
+    """
+    API view to retrieve one from the Emoji model based on its uuid.
+
+    Lookup Field: uuid.
+
+    Request Type: GET.
+    """
+    queryset = Emoji.objects.all()
+    lookup_field = 'uuid'
+    serializer_class = EmojiSerializer
+
+
+# Like views:
+class LikeCreateAPIView(generics.CreateAPIView):
+    """
+    API view to either create (or update from the custom method) from the Like model.
+
+    Request Type: POST.
+    """
+    queryset = Like.objects.all()
+    serializer_class = LikeSerializer
+
+
+class LikeDetailUpdateAPIView(generics.RetrieveUpdateAPIView):
+    """
+    API view to retrieve or update from the Like model based on its uuid.
+
+    Lookup Field: uuid.
+
+    Request Type: GET, PUT, and PATCH.
+    """
+    queryset = Like.objects.all()
+    lookup_field = 'uuid'
+    serializer_class = LikeSerializer


### PR DESCRIPTION
## Changes
1. Created serializers, views, and routes for the `Emoji` and `Like` models.
2. Added the `Like` serializer to the `Product` serializer.
3. Routed the `social` app to the main URL.

## Purpose
There needs to be a REST API for the Social in order for the data to be sent to some client.

## Approach
The `Emoji` serializer outputs a JSON of:

```
{
  "uuid": String,
  "emoji": String,
  "name": String,
}
```

The `Like` serializer has a relation to the `Emoji` and `Product` models, and with its own properties, it would output a JSON of:

```
{
  "uuid": String,
  "like": Integer,
  "emoji": String,
  "product": String
}
```

During the creation method (synonymous to the `POST` method), the `Like` serializer checks if the incoming `uuid` exists. If it does, then it check if both the incoming `emoji` and `product` matches to the extracted model in the DB based on the incoming data. If it doesn't, then it checks to see on the possibility that the incoming `emoji` and `product` exists in the DB. On both of these cases and if it passes, it updates the particular model. On the last conditional, if the incoming `uuid` was not provided, then it checks if the incoming `emoji` and `product` exists in the DB, and if it does, then update. On all other cases, then most likely it is information to be stored in the DB.

The `Like` serializer was also added to the `Product` serializer so that the products could display to the user on the amount of "likes" it has with "emojis".

Once the `Emoji` and `Like` serializers were finished, views were created for retrieving and listing the `Emoji` and `Like` models combined with their serializers.

Then, URLs were wired up to the `Emoji` and `Like` views, and lastly, the main URL was also wired up to the main url file.

Closes #22 