### PR TITLE
Fixed Like View and Allowed Hosts on Django

### DIFF
--- a/server/main/settings.py
+++ b/server/main/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-z*&k=x^^dyz#3*y5&x-6*_uogw*73s3w$cr_+08zzu44oog0q_
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['10.0.0.233', ]
+ALLOWED_HOSTS = ['localhost', '10.0.0.233', ]
 
 
 # Application definition

--- a/server/social/urls.py
+++ b/server/social/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 
 urlpatterns = [
-    path('', views.LikeCreateAPIView.as_view()),
+    path('', views.LikeListCreateAPIView.as_view()),
     path('<uuid:uuid>', views.LikeDetailUpdateAPIView.as_view()),
     path('emojis/', views.EmojiListAPIView.as_view()),
     path('emojis/<uuid:uuid>', views.EmojiDetailAPIView.as_view()),

--- a/server/social/views.py
+++ b/server/social/views.py
@@ -29,11 +29,12 @@ class EmojiDetailAPIView(generics.RetrieveAPIView):
 
 
 # Like views:
-class LikeCreateAPIView(generics.CreateAPIView):
+class LikeListCreateAPIView(generics.ListCreateAPIView):
     """
-    API view to either create (or update from the custom method) from the Like model.
+    API view to either retrieve a list or create (or update from the custom method)
+    from the Like model.
 
-    Request Type: POST.
+    Request Type: GET and POST.
     """
     queryset = Like.objects.all()
     serializer_class = LikeSerializer


### PR DESCRIPTION
## Changes
1. Changed the view for the `like` app to retrieve a list of likes.
2. Added `localhost` to `ALLOWED_HOSTS`.

## Purpose
The `LikeCreateAPIView` has only a creation and not a list of likes, and localhost is not able to communicate to the Django Server.

## Approach
The simple fix was to simply change the generics for `LikeCreateAPIView` from `CreateAPIView` (which does only `POST` method) to `ListCreateAPIView` (which does both `GET` and `POST` methods). Because of this change, the class name needed to be changed in order to better reflect the generics (or what it does) from `LikeCreateAPIView` to `LikeListCreateAPIView`.

Lastly, `localhost` was not able to respond to Django's Server, and so it was added to `ALLOWED_HOSTS`.

Closes #39 
Closes #40 