### PR TITLE
Retrieve All Likes in Product

### DIFF
--- a/server/product/urls.py
+++ b/server/product/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, re_path
 
 from . import views
 
@@ -6,4 +6,6 @@ from . import views
 urlpatterns = [
     path('', views.ProductListAPIView.as_view()),
     path('<slug:slug>', views.ProductDetailAPIView.as_view()),
+    re_path(r'^(?P<product_slug>[\w-]+)/socials/?$',
+            views.ProductLikesModelViewSet.as_view({'get': 'list'})),
 ]

--- a/server/product/views.py
+++ b/server/product/views.py
@@ -35,9 +35,9 @@ class ProductLikesModelViewSet(viewsets.ModelViewSet):
     Model viewset on the Like and Product models. Tries to retrieve all
     likes based on the product's slug, if a GET request.
 
-    Actions: list and retrieve.
+    Actions: list, create, retrieve, update, partial_update, destroy.
 
-    Request Like: GET.
+    Request Like: GET, POST, PATCH, PUT, DELETE.
     """
     queryset = Like.objects.all().select_related(
         'product').select_related('emoji').order_by('product__slug')


### PR DESCRIPTION
## Changes
1. Created custom model viewset on the `Like` and `Product` model which retrieves all likes from the product's slug.
2. Created a nested route to retrieve all likes from the product's slug.

## Purpose
There should be an API call in the `product` app that calls all likes based on the product's slug.

## Approach
In order to get all the likes from the product's slug, a custom view needed to be created in the `product` app. Instead of using the `generics` from the Django REST Framework (which greatly simplifies the view's functionality), the view needed to use the `viewsets` from the Django REST Framework to not just simplify the functionality, but to expand upon it to achieve the desired result.

This custom view is called `ProductLikesModelViewSet` where the first thing it does is to retrieve all of the Like objects and order it by the product's slug. The QuerySet method `select_related` is a performance booster on the foreign key relationships that doesn't hit the database more than once. From there is where the `get_queryset` method would get the list of items from the `Product` model based on its slug and chain it on getting all the likes from the `Like` model. This would return all likes from the product's slug, or raise a not found error if the product could not be found in the database based on the provided slug.

The last thing to do is to wire up the nested routes. Since the Django REST Framework provides simple implementations on routes, the nested routing needed to be achieved by using regular expressions, and the `(?P<name>pattern)` syntax helps with this. The `<name>` in the nested route would be `<product_slug>` which is the group to be tested on by the regular expression `[\w-]+` (this checks if it it matches with words with dashes i.e. a slug). Next, the `as_view` function in the nested route needs to only accept `GET` requests by putting inside the function of `{ 'get': 'list' }` which would return back a list (or array) as a response. If we wanted to get back a dictionary (or object) as a response, then the `as_view` function needs to be bounded by the action of `{ 'get': 'retrieve' }`.

## Learning
[Using Nested Routers DRF-Nested Routers in Django Rest framework](https://medium.com/swlh/using-nested-routers-drf-nested-routers-in-django-rest-framework-951007d55cdc).

[QuerySet API Reference: `selected-related()` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#select-related).

[`django.urls` functions for use in URLconfs: `re_path()` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/urls/#django.urls.re_path).

[URL dispatcher: Using regular expressions - Django documentation](https://docs.djangoproject.com/en/3.2/topics/http/urls/#using-regular-expressions).

[Model class reference: `DoesNotExist` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/models/class/#django.db.models.Model.DoesNotExist).

[Viewsets: ModelViewSet - Django REST framework](https://www.django-rest-framework.org/api-guide/viewsets/#modelviewset).

[Routers - Django REST framework](https://www.django-rest-framework.org/api-guide/routers/).

Closes #48 