### PR TITLE
Retrieve All Likes in Foodtruck

### DIFF
--- a/server/foodtruck/urls.py
+++ b/server/foodtruck/urls.py
@@ -1,8 +1,10 @@
-from django.urls import path
+from django.urls import path, re_path
 
 from . import views
 
 urlpatterns = [
     path('', views.TruckListAPIView.as_view()),
     path('<slug:slug>', views.TruckDetailAPIView.as_view()),
+    re_path(r'^(?P<truck_slug>[\w-]+)/socials/?$',
+            views.TruckLikesModelViewSet.as_view({'get': 'list'})),
 ]

--- a/server/foodtruck/views.py
+++ b/server/foodtruck/views.py
@@ -1,7 +1,10 @@
-from rest_framework import generics
+from rest_framework import generics, viewsets
+from rest_framework.exceptions import NotFound
 
 from .models import Truck
 from .serializers import TruckSerializer
+from social.models import Like
+from social.serializers import LikeSerializer
 
 
 # Truck views:
@@ -26,3 +29,27 @@ class TruckDetailAPIView(generics.RetrieveAPIView):
     queryset = Truck.objects.all().order_by('name')
     lookup_field = 'slug'
     serializer_class = TruckSerializer
+
+
+class TruckLikesModelViewSet(viewsets.ModelViewSet):
+    """
+    Model viewset on the Like and Truck models. Tries to retrieve all
+    likes based on the truck's slug, if a GET request.
+
+    Actions: list, create, retrieve, update, partial_update, destroy.
+
+    Request Synonymous: GET, POST, PATCH, PUT, DELETE.
+    """
+    queryset = Like.objects.all().select_related(
+        'product').select_related('emoji').order_by('product__slug')
+    serializer_class = LikeSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        truck_slug = self.kwargs.get('truck_slug')
+
+        try:
+            truck = Truck.objects.get(slug=truck_slug)
+        except Truck.DoesNotExist:
+            raise NotFound('A truck with this slug does not exist.')
+
+        return self.queryset.filter(product__truck=truck)


### PR DESCRIPTION
## Changes
1. Created custom model viewset on the `Like` and `Truck` models which retrieves all likes from the truck's slug.
2. Created a nested route to retrieve all likes from the truck's slug.

## Purpose
There should be an API call in the `foodtruck` app that calls all likes based on the foodtruck's slug.

## Approach
Similar to #50 , but the difference is in the custom viewset: The `get_queryset` method would get the truck from the `Truck` model based on its slug and chain it on getting all the likes from the `Like` model. This is done by querying across model relations, and since the `Product` has a foreign key from its `truck` attribute, then the filter chaining on the queryset could be accomplished by pointing the field to a different model: `filter(product__truck=truck)`.

## Notes
The `drf-nested-routers` package was not installed nor implemented since this is a small app, and to learn more on regular expressions for routes.

## Learning
[`QuerySet` API reference - Django documentation](https://docs.djangoproject.com/en/3.2/ref/models/querysets/).

Closes #51 