### PR TITLE
Fixed and Refactored the Social and Foodtruck Actions

### DIFF
--- a/client/old-redux/actions/foodtruckActions.js
+++ b/client/old-redux/actions/foodtruckActions.js
@@ -24,5 +24,31 @@ const finishOneFoodtruck = (foodtruck) => ({
 
 export const oneFoodtruck = (slug) => (dispatch) =>
   getFoodtruck(slug, headers())
-    .then((res) => dispatch(finishOneFoodtruck(res)))
+    .then((res) => {
+      const foodtruckData = {
+        uuid: res.uuid,
+        name: res.name,
+        slug: res.slug,
+        info: res.info,
+        phone_number: res.phone_number,
+        email: res.email,
+        website: res.website,
+        images: res.images,
+        events: res.events,
+      };
+
+      let foodtruckSocials = [];
+
+      if (res.products.length) {
+        res.products.forEach((product) => {
+          if (product.likes.length) {
+            product.likes.forEach((like) => {
+              foodtruckSocials.push(like);
+            });
+          }
+        });
+      }
+
+      dispatch(finishOneFoodtruck(foodtruckData));
+    })
     .catch((err) => err);

--- a/client/old-redux/actions/socialActions.js
+++ b/client/old-redux/actions/socialActions.js
@@ -55,5 +55,5 @@ const finishAllSocialsFromProduct = (productSocials) => ({
 
 export const allSocialsFromProduct = (product_slug) => (dispatch) =>
   getAllSocialsFromProduct(product_slug, headers())
-    .then((res) => dispatch())
+    .then((res) => dispatch(finishAllSocialsFromProduct(res)))
     .catch((err) => console.error(err));

--- a/client/old-redux/actions/socialActions.js
+++ b/client/old-redux/actions/socialActions.js
@@ -37,7 +37,7 @@ export const addSocial = (emoji, product_slug, like) => (dispatch) =>
     .catch((err) => console.error(err));
 
 // GET ALL SOCIALS FROM FOODTRUCK
-export const finishAllSocialsFromFoodtruck = (foodtruckSocials) => ({
+const finishAllSocialsFromFoodtruck = (foodtruckSocials) => ({
   type: GET_ALL_FOODTRUCK_SOCIALS,
   payload: { foodtruckSocials },
 });
@@ -48,7 +48,7 @@ export const allSocialsFromFoodtruck = (foodtruck_slug) => (dispatch) =>
     .catch((err) => console.error(err));
 
 // GET ALL SOCIALS FROM PRODUCT
-export const finishAllSocialsFromProduct = (productSocials) => ({
+const finishAllSocialsFromProduct = (productSocials) => ({
   type: GET_ALL_PRODUCT_SOCIALS,
   payload: { productSocials },
 });


### PR DESCRIPTION
## Changes
1. Extracted and separated the foodtruck data to focus only on the foodtruck.
2. Fixed `allSocialsFromProduct` by adding the finish dispatcher with the response data.

## Purpose
When getting a particular foodtruck from its slug, their products' socials should be added to the social reducer.

## Approach
Tackling this issue was ignored since the argument is to keep the functionalities as separate: The foodtruck should only have foodtruck, and the social should focus on the social. This also keeps the data from the server as flat as possible instead of having nested objects/arrays. If getting and using one of the social actions into the foodtruck actions were to occur, then there would be complications and confusions on separating the data especially if the app were to grow (the product, review, and user redux hasn't been implemented yet!). With these reasons, the main focus of this PR was refactoring and fix any bugs.

Closes #55 