### PR TITLE
`axiosinit` Utility Function

### DIFF
--- a/client/api/foodtruckAPI.js
+++ b/client/api/foodtruckAPI.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { axiosInit } from '../utils';
 
 export const getAllFoodtrucks = (headers) =>

--- a/client/api/foodtruckAPI.js
+++ b/client/api/foodtruckAPI.js
@@ -1,15 +1,11 @@
 import axios from 'axios';
-
-const axiosInit = axios.create({
-  baseURL: `http://10.0.0.233:8000/api/v1/foodtrucks/`,
-  responseType: 'json',
-});
+import { axiosInit } from '../utils';
 
 export const getAllFoodtrucks = (headers) =>
   new Promise((resolve, reject) =>
     setTimeout(() => {
       try {
-        axiosInit
+        axiosInit('foodtrucks')
           .get('', headers)
           .then((res) => resolve(res.data))
           .catch((err) => {
@@ -31,7 +27,7 @@ export const getFoodtruck = (slug, headers) =>
   new Promise((resolve, reject) =>
     setTimeout(() => {
       try {
-        axiosInit
+        axiosInit('foodtrucks')
           .get(`${slug}`, headers)
           .then((res) => resolve(res.data))
           .catch((err) => {

--- a/client/api/socialAPI.js
+++ b/client/api/socialAPI.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { axiosInit } from '../utils';
 
 export const getAllSocials = (headers) =>

--- a/client/api/socialAPI.js
+++ b/client/api/socialAPI.js
@@ -1,10 +1,5 @@
 import axios from 'axios';
-
-const axiosInit = (path) =>
-  axios.create({
-    baseURL: `http://10.0.0.233:8000/api/v1/${path}/`,
-    responseType: 'json',
-  });
+import { axiosInit } from '../utils';
 
 export const getAllSocials = (headers) =>
   new Promise((resolve, reject) =>

--- a/client/utils/axiosInit.js
+++ b/client/utils/axiosInit.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+const axiosInit = (path) =>
+  axios.create({
+    baseURL: `http://10.0.0.233:8000/api/v1/${path}/`,
+    responseType: 'json',
+  });
+
+export default axiosInit;

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -1,1 +1,2 @@
+export { default as axiosInit } from './axiosInit';
 export { default as headers } from './headers';


### PR DESCRIPTION
## Changes
1. Created a utility function to initialize `axios`.
2. Refactored the API functions to utilize the utility function.

## Purpose
The `axiosInit` instance in the APIs should be refactored into its own file to be reused.

Closes #57 