### PR TITLE
Retrieve All Products in Foodtruck

### DIFF
--- a/server/foodtruck/urls.py
+++ b/server/foodtruck/urls.py
@@ -5,6 +5,8 @@ from . import views
 urlpatterns = [
     path('', views.TruckListAPIView.as_view()),
     path('<slug:slug>', views.TruckDetailAPIView.as_view()),
+    re_path(r'^(?P<truck_slug>[\w-]+)/products/?$',
+            views.TruckProductsModelViewSet.as_view({'get': 'list'})),
     re_path(r'^(?P<truck_slug>[\w-]+)/socials/?$',
             views.TruckLikesModelViewSet.as_view({'get': 'list'})),
 ]

--- a/server/foodtruck/views.py
+++ b/server/foodtruck/views.py
@@ -3,6 +3,8 @@ from rest_framework.exceptions import NotFound
 
 from .models import Truck
 from .serializers import TruckSerializer
+from product.models import Product
+from product.serializers import ProductSerializer
 from social.models import Like
 from social.serializers import LikeSerializer
 
@@ -29,6 +31,29 @@ class TruckDetailAPIView(generics.RetrieveAPIView):
     queryset = Truck.objects.all().order_by('name')
     lookup_field = 'slug'
     serializer_class = TruckSerializer
+
+
+class TruckProductsModelViewSet(viewsets.ModelViewSet):
+    """
+    Model viewset on the Product and Truck models. Tries to retrieve all
+    likes based on the truck's slug, if a GET request.
+
+    Actions: list, create, retrieve, update, partial_update, destroy.
+
+    Request Synonymous: GET, POST, PATCH, PUT, DELETE.
+    """
+    queryset = Product.objects.all().select_related('truck').order_by('slug')
+    serializer_class = ProductSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        truck_slug = self.kwargs.get('truck_slug')
+
+        try:
+            truck = Truck.objects.get(slug=truck_slug)
+        except Truck.DoesNotExist:
+            raise NotFound('A truck with this slug does not exist.')
+
+        return self.queryset.filter(truck=truck)
 
 
 class TruckLikesModelViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Changes
1. Created custom model viewset on the `Truck` and `Product` models which retrieves all products from the truck's slug.
2. Created a nested route to retrieve all products from the truck's slug.

## Purpose
There should be an API call in the `foodtruck` app that calls all products based on the foodtruck's slug.

## Approach
Refer to #50 for this approach.

Closes #59 