### PR TITLE
Retrieve All Reviews from Product

### DIFF
--- a/server/product/urls.py
+++ b/server/product/urls.py
@@ -6,6 +6,8 @@ from . import views
 urlpatterns = [
     path('', views.ProductListAPIView.as_view()),
     path('<slug:slug>', views.ProductDetailAPIView.as_view()),
+    re_path(r'^(?P<product_slug>[\w-]+)/reviews/?$',
+            views.ProductReviewsModelViewSet.as_view({'get': 'list'})),
     re_path(r'^(?P<product_slug>[\w-]+)/socials/?$',
             views.ProductLikesModelViewSet.as_view({'get': 'list'})),
 ]

--- a/server/product/views.py
+++ b/server/product/views.py
@@ -3,6 +3,8 @@ from rest_framework.exceptions import NotFound
 
 from .models import Product
 from .serializers import ProductSerializer
+from review.models import Review
+from review.serializers import ReviewSerializer
 from social.models import Like
 from social.serializers import LikeSerializer
 
@@ -42,6 +44,30 @@ class ProductLikesModelViewSet(viewsets.ModelViewSet):
     queryset = Like.objects.all().select_related(
         'product').select_related('emoji').order_by('product__slug')
     serializer_class = LikeSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        product_slug = self.kwargs.get('product_slug')
+
+        try:
+            product = Product.objects.get(slug=product_slug)
+        except Product.DoesNotExist:
+            raise NotFound('A product with this slug does not exist.')
+
+        return self.queryset.filter(product=product)
+
+
+class ProductReviewsModelViewSet(viewsets.ModelViewSet):
+    """
+    Model viewset on the Review and Product models. Tries to retrieve all
+    reviews based on the product's slug, if a GET request.
+
+    Actions: list, create, retrieve, update, partial_update, destroy.
+
+    Request Like: GET, POST, PATCH, PUT, DELETE.
+    """
+    queryset = Review.objects.all().select_related(
+        'product').select_related('user').order_by('created_at')
+    serializer_class = ReviewSerializer
 
     def get_queryset(self, *args, **kwargs):
         product_slug = self.kwargs.get('product_slug')


### PR DESCRIPTION
## Changes
1. Created custom model viewset on the `Review` and `Product` models which retrieves all reviews from the product's slug.
2. Created a nested route to retrieve all reviews from the product's slug.

## Purpose
There should be an API call in the `product` app that calls all reviews based on the product's slug.

## Approach
Refer to #50 for this approach.

Closes #63 