### PR TITLE
Retrieve All Reviews from Foodtruck

### DIFF
--- a/server/foodtruck/urls.py
+++ b/server/foodtruck/urls.py
@@ -7,6 +7,8 @@ urlpatterns = [
     path('<slug:slug>', views.TruckDetailAPIView.as_view()),
     re_path(r'^(?P<truck_slug>[\w-]+)/products/?$',
             views.TruckProductsModelViewSet.as_view({'get': 'list'})),
+    re_path(r'^(?P<truck_slug>[\w-]+)/reviews/?$',
+            views.TruckReviewsModelViewSet.as_view({'get': 'list'})),
     re_path(r'^(?P<truck_slug>[\w-]+)/socials/?$',
             views.TruckLikesModelViewSet.as_view({'get': 'list'})),
 ]

--- a/server/foodtruck/views.py
+++ b/server/foodtruck/views.py
@@ -5,6 +5,8 @@ from .models import Truck
 from .serializers import TruckSerializer
 from product.models import Product
 from product.serializers import ProductSerializer
+from review.models import Review
+from review.serializers import ReviewSerializer
 from social.models import Like
 from social.serializers import LikeSerializer
 
@@ -68,6 +70,30 @@ class TruckLikesModelViewSet(viewsets.ModelViewSet):
     queryset = Like.objects.all().select_related(
         'product').select_related('emoji').order_by('product__slug')
     serializer_class = LikeSerializer
+
+    def get_queryset(self, *args, **kwargs):
+        truck_slug = self.kwargs.get('truck_slug')
+
+        try:
+            truck = Truck.objects.get(slug=truck_slug)
+        except Truck.DoesNotExist:
+            raise NotFound('A truck with this slug does not exist.')
+
+        return self.queryset.filter(product__truck=truck)
+
+
+class TruckReviewsModelViewSet(viewsets.ModelViewSet):
+    """
+    Model viewset on the Review and Truck models. Tries to retrieve all
+    reviews based on the truck's slug, if a GET request.
+
+    Actions: list, create, retrieve, update, partial_update, destroy.
+
+    Request Synonymous: GET, POST, PATCH, PUT, DELETE.
+    """
+    queryset = Review.objects.all().select_related(
+        'product').select_related('user').order_by('created_at')
+    serializer_class = ReviewSerializer
 
     def get_queryset(self, *args, **kwargs):
         truck_slug = self.kwargs.get('truck_slug')


### PR DESCRIPTION
## Changes
1. Created custom model viewset on the `Review` and `Truck` models which retrieves all reviews from the foodtruck's slug.
2. Created a nested route to retrieve all reviews from the foodtruck's slug.

## Purpose
There should be an API call in the `foodtruck` app that calls all reviews based on the foodtruck's slug.

## Approach
Refer to #50 for this approach.

Closes #65 