### PR TITLE
Sent out the user's username instead of uuid in Server

### DIFF
--- a/server/review/serializers.py
+++ b/server/review/serializers.py
@@ -16,7 +16,7 @@ class ReviewSerializer(serializers.ModelSerializer):
     product = serializers.SlugRelatedField(
         slug_field='slug', queryset=Product.objects.all())
     user = serializers.SlugRelatedField(
-        slug_field='uuid', queryset=CustomUser.objects.all())
+        slug_field='username', queryset=CustomUser.objects.all())
 
     class Meta:
         model = Review


### PR DESCRIPTION
## Changes
1. Changed the `slug_field` from `uuid` to `username`.

## Purpose
The user's `username` should be displayed instead of the `uuid`.

Closes #73 