### PR TITLE
Fixed `newSocials` in `socialReducer`

### DIFF
--- a/client/old-redux/reducers/socialReducer.js
+++ b/client/old-redux/reducers/socialReducer.js
@@ -22,7 +22,7 @@ const newSocials = (stateArray, actionPayload) => {
     const clonedSocial = { ...social };
 
     if (clonedSocial.uuid === actionPayload.uuid) {
-      clonedSocial.like += actionPayload.like;
+      clonedSocial.like = actionPayload.like;
       uuidExists = true;
     }
 


### PR DESCRIPTION
## Changes
1. Removed increment from the `newSocials` function.

## Purpose
The likes are doubly-incrementing with each new social being sent.

Closes #75 