### PR TITLE
Slug Generator

### DIFF
--- a/server/foodtruck/models.py
+++ b/server/foodtruck/models.py
@@ -1,8 +1,11 @@
 import os
 from django.db import models
+from django.db.models.signals import pre_save
 from django.utils import timezone
 from phonenumber_field.modelfields import PhoneNumberField
 from uuid import uuid4
+
+from main.utils import slug_generator
 
 
 def upload_truckimage_to(instance, filename):
@@ -54,3 +57,6 @@ class TruckImage(models.Model):
     updated_at = models.DateTimeField(auto_now=True, blank=True, null=True)
     truck = models.ForeignKey(
         Truck, related_name='images', on_delete=models.CASCADE)
+
+
+pre_save.connect(slug_generator, sender=Truck)

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -1,0 +1,45 @@
+import random
+import string
+from django.utils.text import slugify
+
+
+def random_string_generator(size=10, chars=string.ascii_lowercase + string.digits):
+    """
+    Generates a random string.
+    """
+    return ''.join(random.choice(chars) for _ in range(size))
+
+
+def unique_slug_generator(instance, new_slug=None):
+    """
+    Assumes your instance has a model with a slug field and a name character (char) field.
+
+    Returns: unique slug from the Model's name if the slug query exists in DB, or the newly
+    created slug that slugifies the Model's name if the slug query does not exist in DB.
+    """
+    if new_slug is not None:
+        slug = new_slug
+    else:
+        slug = slugify(instance.name)
+
+    model = instance.__class__
+    queryset_exists = model.objects.filter(slug=slug).exists()
+
+    if queryset_exists:
+        unique_slug = '{slug}-{randstr}'.format(
+            slug=slug, randstr=random_string_generator(size=4))
+
+        # Run this function again to check if the uniquely random slug is truly unique
+        # in the DB. If it is unique, return this unique slug (line 35). Otherwise,
+        # generate another unique slug. Rinse and repeat.
+        return unique_slug_generator(instance, new_slug=unique_slug)
+
+    return slug
+
+
+def slug_generator(sender, instance, *args, **kwargs):
+    """
+    Converts the string into a slug if it is not present.
+    """
+    if not instance.slug:
+        instance.slug = unique_slug_generator(instance)

--- a/server/product/models.py
+++ b/server/product/models.py
@@ -1,7 +1,10 @@
 import os
 from django.db import models
+from django.db.models.signals import pre_save
 from django.utils import timezone
 from uuid import uuid4
+
+from main.utils import slug_generator
 
 
 def upload_to(instance, filename):
@@ -34,3 +37,6 @@ class Product(models.Model):
     updated_at = models.DateTimeField(auto_now=True, blank=True, null=True)
     truck = models.ForeignKey(
         'foodtruck.Truck', related_name='products', on_delete=models.CASCADE)
+
+
+pre_save.connect(slug_generator, sender=Product)


### PR DESCRIPTION
## Changes
1. Created a custom `slug_generator` function to create unique slugs for the models.
2. Added `slug_generator` with the `Product` and `Truck` models to add the slugs before the model saves.

## Purpose
When another Foodtruck has the same food name as another Foodtruck's product (a Foodtruck could have the same "Chicken Taco"), the slug name would not be unique and conflict leading to an error and a bad user experience.

## Approach
In order to generate a unique slug, a `slug_generator` was created which uniquely generates a slug for the `name` field of the model. This is done by checking if the slug exists in the database, and if it doesn't exist, then it is considered to be unique and therefore it returns that slug. Otherwise, if the slug does exist in the database, then it is not unique and therefore it generates a unique slug by appending random strings. Then, it runs the function again to check if the uniquely generated slug is truly unique in the database. If it is unique, return that unique slug. If not, then rinse and repeat.

Lastly, this `slug_generator` was used with the `pre_save` signal in the `/product.models` and `/foodtruck.models` where the signal would run before the models are saved in the database. As a side note, it was used in `/foodtruck.models` in order to just generate and save it even though the `name` field is unique. This way, the user or developers do not have to manually insert a slug.

Closes #81 