### PR TITLE
User Admin (Django)

### DIFF
--- a/server/main/urls.py
+++ b/server/main/urls.py
@@ -13,6 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include
 
@@ -24,4 +26,4 @@ urlpatterns = [
     path('api/v1/products/', include('product.urls')),
     path('api/v1/reviews/', include('review.urls')),
     path('api/v1/socials/', include('social.urls')),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/server/user/admin.py
+++ b/server/user/admin.py
@@ -1,3 +1,42 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
 
-# Register your models here.
+from .models import CustomUser
+
+
+# USER ADMIN
+class CustomUserAdmin(UserAdmin):
+    """
+    Admin Form for CustomUser by subclassing UserAdmin.
+    """
+    model = CustomUser
+
+    # Viewing all users
+    list_display = ('username', 'email', 'is_staff', 'is_superuser',
+                    'is_active', 'date_joined', 'last_login',)
+    list_filter = ('username', 'email', 'is_staff',
+                   'is_superuser', 'is_active',)
+    search_fields = ('username', 'email',)
+    ordering = ('username',)
+
+    # Viewing and changing one user
+    fieldsets = (
+        (None, {'fields': ('username', 'email', 'password',)}),
+        ('Profile Image', {'fields': ('profile_image',)}),
+        ('Permissions', {'fields': ('is_staff', 'is_superuser', 'is_active')}),
+        ('Additional Info', {
+         'fields': ('uuid', 'date_joined', 'last_login',)}),
+    )
+    readonly_fields = ('uuid', 'date_joined', 'last_login',)
+
+    # Adding one new user
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('username', 'email', 'password1',
+                       'password2', 'is_staff', 'is_active',)
+        }),
+    )
+
+
+admin.site.register(CustomUser, CustomUserAdmin)

--- a/server/user/admin.py
+++ b/server/user/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.utils.html import format_html
 
 from .models import CustomUser
 
@@ -22,12 +23,12 @@ class CustomUserAdmin(UserAdmin):
     # Viewing and changing one user
     fieldsets = (
         (None, {'fields': ('username', 'email', 'password',)}),
-        ('Profile Image', {'fields': ('profile_image',)}),
+        ('Profile Image', {'fields': ('profile_image', 'image_tag',)}),
         ('Permissions', {'fields': ('is_staff', 'is_superuser', 'is_active')}),
         ('Additional Info', {
          'fields': ('uuid', 'date_joined', 'last_login',)}),
     )
-    readonly_fields = ('uuid', 'date_joined', 'last_login',)
+    readonly_fields = ('uuid', 'date_joined', 'last_login', 'image_tag',)
 
     # Adding one new user
     add_fieldsets = (
@@ -37,6 +38,14 @@ class CustomUserAdmin(UserAdmin):
                        'password2', 'is_staff', 'is_active',)
         }),
     )
+
+    # Adding preview image.
+    def image_tag(self, obj):
+        if obj.profile_image:
+            return format_html('<img src="{0}" style="width: 45px; height: 45px;" />'.format(obj.profile_image.url))
+        else:
+            return '(No image)'
+    image_tag.short_description = 'Preview'
 
 
 admin.site.register(CustomUser, CustomUserAdmin)

--- a/server/user/models.py
+++ b/server/user/models.py
@@ -35,3 +35,6 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     REQUIRED_FIELDS = ['username']
 
     objects = CustomUserManager()
+
+    class Meta:
+        verbose_name = 'User'


### PR DESCRIPTION
## Changes
1. Created a model admin for the `CustomUser` model by subclassing the `UserAdmin`.
2. Fixed and served static files by adding it to `main.urls`.

## Purpose
There needs to be a User interface on the admin site, and the static files are not being displayed nor accessed and needs to be fixed.

## Approach
To put the `CustomUser` model into the admin so that it could be editable and viewed, a model admin was created which is called `CustomUserAdmin`. This model admin subclasses the `UserAdmin` which renders the admin look for the `CustomUser` model and it also uses `UserChangeForm` and `UserCreationForm` as the forms to be used when modifying/creating the object. While this sounds really nice, the current downside to this is a new `CustomUser` model was created which means that `UserChangeForm` and `UserCreationForm` have no way to know to use it. In the future, this would be resolved when tackling the issues on generating forms.

Next, to view users in the admin, the configurations of `list_display`, `list_filter`, `search_fields`, and `ordering` were used. The `list_display` configuration is used on which fields on the model would be displayed, `list_filter` is used for filtering (displays on the right sidebar), `search_fields` would be used for searching on the given fields on the model, and the `ordering` is used for how lists of objects are ordered.

To view and change a user in the admin, the configuration of `fieldsets` along with `readonly_fields` were used. The `fieldsets` configuration is used to control the admin layout of adding and changing the model (in this case, it is mainly used for the changing the user), and the `readonly_fields` by displaying fields from the model as non-editable.

To create a new user in the admin, the configuration of `add_fieldsets` was used.

To add a preview to the image, a `image_tag` function was used and was put inside the `fieldsets`. Yet, it has to be non-editable or else an error would occur, and thus `image_tag` was added to the `readonly_fields`.

The last thing is a bug fix where the static files like the images were not being displayed, and the fix was to wire up the static files to `main.urls` in order for Django to serve them in the views.

## Learning
[The Django admin site: `list_display` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display).

[The Django admin site: `list_filter` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_filter).

[The Django admin site: `search_fields` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields).

[The Django admin site: `ordering` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.ordering).

[The Django admin site: `fieldsets` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.fieldsets).

[The Django admin site: `readonly_fields` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.readonly_fields).

Closes #83 
Closes #89 