### PR TITLE
Foodtruck Admin (Django)

### DIFF
--- a/server/foodtruck/admin.py
+++ b/server/foodtruck/admin.py
@@ -6,7 +6,9 @@ from .models import Truck, TruckImage
 
 # TRUCK IMAGE INLINE
 class TruckImageInline(admin.StackedInline):
-    """"""
+    """
+    Inline Model Admin for the TruckImage model.
+    """
     model = TruckImage
 
     fieldsets = (
@@ -30,7 +32,11 @@ class TruckImageInline(admin.StackedInline):
 
 # TRUCK ADMIN
 class TruckAdmin(admin.ModelAdmin):
-    """"""
+    """
+    Model Admin for the Truck model.
+
+    Inlines: TruckImageInline.
+    """
     model = Truck
 
     # Viewing all trucks
@@ -65,7 +71,7 @@ class TruckAdmin(admin.ModelAdmin):
     # To be viewed on the truck since the image model has a foreign key.
     inlines = (TruckImageInline,)
 
-    # Adding preview image.
+    # Adding preview image from the TruckImage.
     @admin.display(description='Preview')
     def image_tag(self, obj):
         queryset = TruckImage.objects.filter(
@@ -77,11 +83,13 @@ class TruckAdmin(admin.ModelAdmin):
 
         return '(No profile image)'
 
+    # To display the add_fieldsets on the creation page.
     def get_fieldsets(self, request, obj=None):
         if not obj:
             return self.add_fieldsets
         return super(TruckAdmin, self).get_fieldsets(request, obj)
 
+    # To not display the inlines on the creation page.
     def get_inline_instances(self, request, obj):
         return obj and super(TruckAdmin, self).get_inline_instances(request, obj) or []
 

--- a/server/foodtruck/models.py
+++ b/server/foodtruck/models.py
@@ -45,6 +45,9 @@ class Truck(models.Model):
     def __str__(self):
         return self.name
 
+    class Meta:
+        verbose_name = 'Foodtruck'
+
 
 class TruckImage(models.Model):
     """
@@ -60,6 +63,9 @@ class TruckImage(models.Model):
     updated_at = models.DateTimeField(auto_now=True, blank=True, null=True)
     truck = models.ForeignKey(
         Truck, related_name='images', on_delete=models.CASCADE)
+
+    class Meta:
+        verbose_name = 'Foodtruck Image'
 
 
 pre_save.connect(slug_generator, sender=Truck)

--- a/server/foodtruck/models.py
+++ b/server/foodtruck/models.py
@@ -42,6 +42,9 @@ class Truck(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     updated_at = models.DateTimeField(auto_now=True, blank=True, null=True)
 
+    def __str__(self):
+        return self.name
+
 
 class TruckImage(models.Model):
     """


### PR DESCRIPTION
## Changes
1. Created a model admin called `TruckAdmin` for the `Truck` model.
2. Created an admin inline called `TruckImageInline` with the `TruckImage` model and embedded it to the `TruckAdmin`.

## Purpose
There needs to be a Foodtruck interface on the admin site.

## Approach
To put the `Foodtruck` model into the admin so that it could be editable and viewed, a model admin was created called `TruckAdmin` which subclasses the `ModelAdmin`. The usual configurations on viewing the foodtrucks were created (`list_display`, `list_filter`, `search_fields`, and `ordering`). The usual configurations on viewing and changing one foodtruck were created (`fieldsets` and `readonly_fields`). Lastly, the usual configurations on adding a new foodtruck was created (`add_fieldsets`). Yet, adding `add_fieldsets` is not enough to display the selected fields when creating because by default the Django admin uses both the `fieldsets` and `readonly_fields`. To overcome this, the `get_fieldsets` method was used which further controls the layout on the admin page than the `fieldsets`, and in this function it checks to see if it is in the creation page (hence the `if not obj`). If it is, then it returns the `add_fieldsets`, but anything other than the creation page would just return the `fieldsets`.

An inline was also created which has the ability to edit models on the same page as a parent model. This is useful for a model that has a foreign key that needs to be displayed on the parent model. In this case, since the `TruckImage` model has a foreign key on the `Truck` model, the `TruckImage` model would need to be displayed and edited as an inline to the `TruckAdmin` (if one wishes to show or edit data from a foreign key, then inlines are extremely useful). Therefore, a `TruckImageInline` was created which displays the image (`image_tag` method) if it is available, and it has `min_num` and `max_num` options to display the minimum and maximum inline amounts to be displayed.

Once this `TruckImageInline` was created, it would be displayed when viewing and changing one foodtruck, but it also displays when adding a new foodtruck. To not display it on the creation page, the `get_inline_instances` method was used where, like the `get_fieldsets`, it checks if the object exists (or if it is a view/update page) and returns the `inlines` configuration. Otherwise, if the object does not exist (if it is the creation page), then it does not return the `inlines` defined earlier, but instead overrides it and returns an empty array.

Last of all, in the `TruckAdmin`, an image was returned (`image_tag`) in viewing all foodtrucks page as a neat feature where it checks if the `TruckImage` belonging to the `Truck` has an image list. If it does belong to the `Truck` and there is a list, then it checks if any of the images have a `is_profile_image` set to `True`. If it is does have a profile image, then it displays it. On all cases that fails, it would simply say `(No profile image)`.

## Learning
[The Django admin site: `get_fieldsets` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_fieldsets).

[The Django admin site: `InlineModelAdmin` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#inlinemodeladmin-objects).

[The Django admin site: `get_inline_instances` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_inline_instances).

Closes #84 