### PR TITLE
Product Admin (Django)

### DIFF
--- a/server/foodtruck/admin.py
+++ b/server/foodtruck/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.utils.html import format_html
 
 from .models import Truck, TruckImage
+from product.admin import ProductInline
 
 
 # TRUCK IMAGE INLINE
@@ -69,7 +70,7 @@ class TruckAdmin(admin.ModelAdmin):
     )
 
     # To be viewed on the truck since the image model has a foreign key.
-    inlines = (TruckImageInline,)
+    inlines = (TruckImageInline, ProductInline,)
 
     # Adding preview image from the TruckImage.
     @admin.display(description='Preview')

--- a/server/foodtruck/models.py
+++ b/server/foodtruck/models.py
@@ -64,6 +64,9 @@ class TruckImage(models.Model):
     truck = models.ForeignKey(
         Truck, related_name='images', on_delete=models.CASCADE)
 
+    def __str__(self):
+        return f'{self.truck.name} {"profile image" if self.is_profile_image else "image"}'
+
     class Meta:
         verbose_name = 'Foodtruck Image'
 

--- a/server/product/admin.py
+++ b/server/product/admin.py
@@ -11,8 +11,6 @@ class ProductInline(admin.StackedInline):
     """
     model = Product
 
-    list_display = ('name',)
-
     fieldsets = (
         (None, {'fields': ('name', 'image', 'image_tag', 'info', 'price',
          'quantity', 'is_available',)}),

--- a/server/product/admin.py
+++ b/server/product/admin.py
@@ -1,3 +1,53 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
-# Register your models here.
+from .models import Product
+
+
+class ProductAdmin(admin.ModelAdmin):
+    """
+    Model Admin for the Product model.
+    """
+    model = Product
+
+    # Viewing all products
+    list_display = ('name', 'truck', 'quantity', 'is_available',
+                    'created_at', 'updated_at', 'image_tag',)
+    list_display_links = ('name', 'truck',)
+    list_filter = ('name', 'truck', 'is_available',)
+    search_fields = ('name', 'truck__name',)
+    ordering = ('slug',)
+
+    # Viewing and changing on product
+    fieldsets = (
+        (None, {'fields': ('name', 'info', 'price',
+         'quantity', 'is_available', 'truck',)}),
+        ('Product Image', {'fields': ('image', 'image_tag')}),
+        ('Additional Info', {
+         'fields': ('uuid', 'slug', 'created_at', 'updated_at',)}),
+    )
+    readonly_fields = ('uuid', 'slug', 'created_at',
+                       'updated_at', 'image_tag',)
+
+    # Adding one new product
+    add_fieldset = (
+        (None, {'fields': ('name', 'info', 'price',
+         'quantity', 'is_available', 'truck',)}),
+    )
+
+    # Adding preview image.
+    @admin.display(description='Preview')
+    def image_tag(self, obj):
+        if obj.image:
+            return format_html('<img src="{0}" style="width: 45px; height: 45px;" />'.format(obj.image.url))
+        else:
+            return '(No image)'
+
+    # To display the add_fielsets on the creation page.
+    def get_fieldsets(self, request, obj=None):
+        if not obj:
+            return self.add_fieldset
+        return super(ProductAdmin, self).get_fieldsets(request, obj)
+
+
+admin.site.register(Product, ProductAdmin)

--- a/server/product/admin.py
+++ b/server/product/admin.py
@@ -4,6 +4,33 @@ from django.utils.html import format_html
 from .models import Product
 
 
+# PRODUCT INLINE
+class ProductInline(admin.StackedInline):
+    """
+    Inline Model Admin for the Product model.
+    """
+    model = Product
+
+    list_display = ('name',)
+
+    fieldsets = (
+        (None, {'fields': ('name', 'image', 'image_tag', 'info', 'price',
+         'quantity', 'is_available',)}),
+    )
+    readonly_fields = ('image_tag',)
+
+    min_num = 1
+
+    # Adding preview image.
+    @admin.display(description='Preview')
+    def image_tag(self, obj):
+        if obj.image:
+            return format_html('<img src="{0}" style="width: 45px; height: 45px" />'.format(obj.image.url))
+        else:
+            return '(No image)'
+
+
+# PRODUCT ADMIN
 class ProductAdmin(admin.ModelAdmin):
     """
     Model Admin for the Product model.

--- a/server/product/models.py
+++ b/server/product/models.py
@@ -38,5 +38,8 @@ class Product(models.Model):
     truck = models.ForeignKey(
         'foodtruck.Truck', related_name='products', on_delete=models.CASCADE)
 
+    def __str__(self):
+        return self.name
+
 
 pre_save.connect(slug_generator, sender=Product)


### PR DESCRIPTION
## Changes
1. Created a model admin called `ProductAdmin` for the `Product` model.
2. Created an admin inline called `ProductInline` with the `Product` model and embedded it to the `TruckAdmin`.

## Purpose
There needs to be a Product interface on the admin site.

## Approach
Similar to approach with #91 , but the bonus feature is creating an inline called `ProductInline` and added it to the `TruckAdmin`.

Closes #86 