### PR TITLE
Social Admins (Django)

### DIFF
--- a/server/foodtruck/admin.py
+++ b/server/foodtruck/admin.py
@@ -69,7 +69,7 @@ class TruckAdmin(admin.ModelAdmin):
         }),
     )
 
-    # To be viewed on the truck since the image model has a foreign key.
+    # To be viewed on the truck since the these models have a foreign key.
     inlines = (TruckImageInline, ProductInline,)
 
     # Adding preview image from the TruckImage.

--- a/server/product/admin.py
+++ b/server/product/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.utils.html import format_html
 
 from .models import Product
-from social.admin import LikeInline
+from social.admin import AddLikeInline, ViewLikeInline
 
 
 # PRODUCT INLINE
@@ -62,7 +62,7 @@ class ProductAdmin(admin.ModelAdmin):
     )
 
     # To be viewed on the product since these models have a foreign key.
-    inlines = (LikeInline,)
+    inlines = (AddLikeInline, ViewLikeInline,)
 
     # Adding preview image.
     @admin.display(description='Preview')

--- a/server/product/admin.py
+++ b/server/product/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.utils.html import format_html
 
 from .models import Product
+from social.admin import LikeInline
 
 
 # PRODUCT INLINE
@@ -59,6 +60,9 @@ class ProductAdmin(admin.ModelAdmin):
         (None, {'fields': ('name', 'info', 'price',
          'quantity', 'is_available', 'truck',)}),
     )
+
+    # To be viewed on the product since these models have a foreign key.
+    inlines = (LikeInline,)
 
     # Adding preview image.
     @admin.display(description='Preview')

--- a/server/social/admin.py
+++ b/server/social/admin.py
@@ -6,7 +6,9 @@ from .models import Emoji, Like
 
 
 class EmojiAdmin(admin.ModelAdmin):
-    """"""
+    """
+    Model Admin for the Emoji model. 
+    """
     model = Emoji
 
     # View all emojis
@@ -35,7 +37,9 @@ class EmojiAdmin(admin.ModelAdmin):
 
 
 class LikeAdmin(admin.ModelAdmin):
-    """"""
+    """
+    Model Admin for the Like model.
+    """
     model = Like
 
     # View all likes

--- a/server/social/admin.py
+++ b/server/social/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
 
 from .models import Emoji, Like
 
@@ -14,7 +16,7 @@ class EmojiAdmin(admin.ModelAdmin):
     search_fields = ('emoji', 'name',)
     ordering = ('name',)
 
-    # View and changing one emoji
+    # Viewing and changing one emoji
     fieldsets = (
         (None, {'fields': ('emoji', 'name',)}),
         ('Additional Info', {'fields': ('uuid', 'created_at', 'updated_at',)}),
@@ -32,4 +34,46 @@ class EmojiAdmin(admin.ModelAdmin):
         return super(EmojiAdmin, self).get_fieldsets(request, obj)
 
 
+class LikeAdmin(admin.ModelAdmin):
+    """"""
+    model = Like
+
+    # View all likes
+    list_display = ('like', 'link_to_emoji', 'link_to_product',
+                    'created_at', 'updated_at',)
+    list_display_links = ('like',)
+    list_filter = ('like', 'emoji', 'product',)
+    search_fields = ('like', 'emoji__emoji', 'emoji__name', 'product__name',)
+    ordering = ('-like',)
+
+    # Viewing and changing one like
+    fieldsets = (
+        ('Additional Info', {'fields': ('uuid', 'created_at', 'updated_at',)}),
+    )
+    readonly_fields = ('uuid', 'created_at', 'updated_at',)
+
+    # Adding one new like
+    add_fieldset = (
+        (None, {'fields': ('like', 'emoji', 'product',)}),
+    )
+
+    # Custom link to the emoji's change page instead of the like change page.
+    @admin.display(description='Emoji')
+    def link_to_emoji(self, obj):
+        link = reverse('admin:social_emoji_change', args=[obj.emoji.id])
+        return format_html('<a href="{}">{}</a>', link, obj.emoji)
+
+    # Custom link to the product's change page.
+    @admin.display(description='Product')
+    def link_to_product(self, obj):
+        link = reverse('admin:product_product_change', args=[obj.product.id])
+        return format_html('<a href="{}">{}</a>', link, obj.product)
+
+    def get_fieldsets(self, request, obj=None):
+        if not obj:
+            return self.add_fieldset
+        return super(LikeAdmin, self).get_fieldsets(request, obj)
+
+
 admin.site.register(Emoji, EmojiAdmin)
+admin.site.register(Like, LikeAdmin)

--- a/server/social/admin.py
+++ b/server/social/admin.py
@@ -1,3 +1,35 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Emoji, Like
+
+
+class EmojiAdmin(admin.ModelAdmin):
+    """"""
+    model = Emoji
+
+    # View all emojis
+    list_display = ('emoji', 'name', 'created_at', 'updated_at',)
+    list_display_links = ('emoji', 'name',)
+    list_filter = ('emoji', 'name',)
+    search_fields = ('emoji', 'name',)
+    ordering = ('name',)
+
+    # View and changing one emoji
+    fieldsets = (
+        (None, {'fields': ('emoji', 'name',)}),
+        ('Additional Info', {'fields': ('uuid', 'created_at', 'updated_at',)}),
+    )
+    readonly_fields = ('uuid', 'created_at', 'updated_at',)
+
+    # Adding one new emoji
+    add_fieldset = (
+        (None, {'fields': ('emoji', 'name')}),
+    )
+
+    def get_fieldsets(self, request, obj=None):
+        if not obj:
+            return self.add_fieldset
+        return super(EmojiAdmin, self).get_fieldsets(request, obj)
+
+
+admin.site.register(Emoji, EmojiAdmin)

--- a/server/social/admin.py
+++ b/server/social/admin.py
@@ -5,6 +5,7 @@ from django.utils.html import format_html
 from .models import Emoji, Like
 
 
+# EMOJI ADMIN
 class EmojiAdmin(admin.ModelAdmin):
     """
     Model Admin for the Emoji model. 
@@ -36,6 +37,21 @@ class EmojiAdmin(admin.ModelAdmin):
         return super(EmojiAdmin, self).get_fieldsets(request, obj)
 
 
+# LIKE INLINE
+class LikeInline(admin.TabularInline):
+    """
+    Inline Model Admin for the Like model.
+    """
+    model = Like
+
+    fieldsets = (
+        (None, {'fields': ('like', 'emoji',)}),
+    )
+
+    min_num = 1
+
+
+# LIKE ADMIN
 class LikeAdmin(admin.ModelAdmin):
     """
     Model Admin for the Like model.

--- a/server/social/admin.py
+++ b/server/social/admin.py
@@ -37,18 +37,42 @@ class EmojiAdmin(admin.ModelAdmin):
         return super(EmojiAdmin, self).get_fieldsets(request, obj)
 
 
-# LIKE INLINE
-class LikeInline(admin.TabularInline):
+# LIKE INLINES
+class ViewLikeInline(admin.TabularInline):
     """
-    Inline Model Admin for the Like model.
+    Inline Model Admin for viewing the Like model.
     """
     model = Like
+    verbose_name = 'View Social'
+    verbose_name_plural = 'View Socials'
 
-    fieldsets = (
-        (None, {'fields': ('like', 'emoji',)}),
-    )
+    extra = 0
 
-    min_num = 1
+    fields = ('like', 'emoji', 'created_at', 'updated_at',)
+    readonly_fields = ('like', 'emoji', 'created_at', 'updated_at',)
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
+class AddLikeInline(admin.TabularInline):
+    """
+    Inline Model Admin for the adding to the Like model.
+    """
+    model = Like
+    verbose_name = 'Add Social'
+    verbose_name_plural = 'Add Socials'
+
+    extra = 0
+    max_num = 1
+
+    fields = ('like', 'emoji',)
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return False
 
 
 # LIKE ADMIN

--- a/server/social/models.py
+++ b/server/social/models.py
@@ -13,7 +13,7 @@ class Emoji(models.Model):
     updated_at = models.DateTimeField(auto_now=True, blank=True, null=True)
 
     def __str__(self):
-        return f'{self.emoji} {self.name}'
+        return f'{self.emoji} ({self.name})'
 
 
 class Like(models.Model):

--- a/server/social/models.py
+++ b/server/social/models.py
@@ -12,6 +12,9 @@ class Emoji(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     updated_at = models.DateTimeField(auto_now=True, blank=True, null=True)
 
+    def __str__(self):
+        return f'{self.emoji} {self.name}'
+
 
 class Like(models.Model):
     """

--- a/server/social/models.py
+++ b/server/social/models.py
@@ -30,3 +30,9 @@ class Like(models.Model):
         Emoji, related_name='likes', on_delete=models.CASCADE)
     product = models.ForeignKey(
         'product.Product', related_name='likes', on_delete=models.CASCADE)
+
+    def __str__(self):
+        return f'{self.like} {self.emoji} on {self.product} ({self.product.truck})'
+
+    class Meta:
+        verbose_name = 'Social'


### PR DESCRIPTION
## Changes
1. Created model admins (`EmojiAdmin` and `LikeAdmin`) for the `Emoji` and `Like` models.
2. Created admin inlines called `ViewLikeInline` and `AddLikeInline` with the `Like` model, and embedded it to the `ProductAdmin`.

## Purpose
There needs to be a Social interface on the admin site.

## Approach
Similar to #91 and #92 , but with some new features. One of the new features are the additions of the two `Like` inlines: `ViewLikeInline` and `AddLikeInline`. Usually, when adding an inline to another admin model, it would display all of the rows from the child model that has a foreign key relationship to the parent model, and it would also have the option to create a new one or update the selected row. This is a problem because it would not be ethically sound to update a "like" from a particular product either from the owner wanting to change it, or letting the developer having too much power on how the user should perceive a product. Therefore, instead of having a single inline like `LikeInline`, two were created where `ViewLikeInline` would only display the existence of rows related to the product while the `AddLikeInline` would only add one creation. In the `AddLikeInline`, the options of `extra=0` and `max_num=1` helps to force the developer/user to manually add one while never chaining another one at the same time, and additionally the methods of `has_change_permission` and `has_view_permission` were set to `False` so it could only focus on adding. In the `VewLikeInline`, the option of `extra=0` ensures that no other fields of adding can occur while the method `has_add_permission` was set to `False` to further solidify on only viewing the data. To go even further, the fields `like`, `emoji`, `created_at`, and `updated_at` were set to read only which helps to avoid any changes.

Another neat feature is by creating methods for adding custom links to the product's and emoji's change page (`link_to_product` and `link_to_emoji`). This was done by utilizing the `reverse` function where it uses the similarity of the `url` template tag. The `url` template tag returns an absolute path reference (a URL without the domain name) matching a given view and optional parameters, and this is used in the `reverse` function by providing a namespace. The namespace helps to uniquely reverse named URL patterns even if different applications use the same URL names. A namespace comes in two parts: an application namespace and an instance namespace. An application namespace describes the name of the application being deployed while the instance namespace identifies a specific instance of an application. For both `link_to_product` and `link_to_emoji`, they have namespaces of `admin:product_product_change` and `admin:social_emoji_change`, respectively. The `admin` part is the application namespace which is Django's built-in application, and the `product_product_change` refers to: 1) the `product` app, 2) the name of the model, and 3) the `change` is the built-in Django view. The last one is the `args` which takes in the `id` of the model so that the built-in Django view could wire things together. Finally, the `link_to_product` and `link_to_emoji` would be stored as links in order to dynamically point to their change pages instead of the current change page.

## Learning
[URL dispatcher: URL namespaces - Django documentation](https://docs.djangoproject.com/en/3.2/topics/http/urls/#url-namespaces).

[`django.urls` utility functions: `reverse()` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/urlresolvers/#reverse).

[The Django admin site: `has_add_permission` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.has_add_permission).

[The Django admin site: `has_change_permission` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.has_change_permission).

[The Django admin site: `has_view_permission` - Django documentation](https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.has_view_permission).

Closes #88 