### PR TITLE
Review Admin (Django)

### DIFF
--- a/server/product/admin.py
+++ b/server/product/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.utils.html import format_html
 
 from .models import Product
+from review.admin import AddReviewInline, ViewReviewInline
 from social.admin import AddLikeInline, ViewLikeInline
 
 
@@ -62,7 +63,8 @@ class ProductAdmin(admin.ModelAdmin):
     )
 
     # To be viewed on the product since these models have a foreign key.
-    inlines = (AddLikeInline, ViewLikeInline,)
+    inlines = (AddLikeInline, ViewLikeInline,
+               AddReviewInline, ViewReviewInline,)
 
     # Adding preview image.
     @admin.display(description='Preview')

--- a/server/product/admin.py
+++ b/server/product/admin.py
@@ -77,7 +77,12 @@ class ProductAdmin(admin.ModelAdmin):
     # To display the add_fielsets on the creation page.
     def get_fieldsets(self, request, obj=None):
         if not obj:
+            self.inlines = []
             return self.add_fieldset
+
+        self.inlines = (AddLikeInline, ViewLikeInline,
+                        AddReviewInline, ViewReviewInline,)
+
         return super(ProductAdmin, self).get_fieldsets(request, obj)
 
 

--- a/server/review/admin.py
+++ b/server/review/admin.py
@@ -1,3 +1,55 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
 
-# Register your models here.
+from .models import Review
+
+
+# REVIEW ADMIN
+class ReviewAdmin(admin.ModelAdmin):
+    """
+    Model Admin for the Review model.
+    """
+    model = Review
+
+    # View all reviews
+    list_display = ('review', 'link_to_product',
+                    'link_to_user', 'created_at', 'updated_at',)
+    list_filter = ('product', 'user', 'product__truck',)
+    search_fields = ('product__name', 'user__email', 'user__username',)
+    ordering = ('-created_at',)
+
+    # View and change one review
+    fieldsets = (
+        (None, {'fields': ('review', 'product', 'user',)}),
+        ('Additional Info', {'fields': ('uuid', 'created_at', 'updated_at',)}),
+    )
+    readonly_fields = ('uuid', 'created_at', 'updated_at', 'product', 'user',)
+
+    # Add one review
+    add_fieldset = (
+        (None, {'fields': ('review', 'product', 'user',)}),
+    )
+
+    # Custom link to the product's change page.
+    @admin.display(description='Product')
+    def link_to_product(self, obj):
+        link = reverse('admin:product_product_change', args=[obj.product.id])
+        return format_html('<a href="{}">{}</a>', link, f'{obj.product} ({obj.product.truck})')
+
+    # Custom link to the user's change page.
+    @admin.display(description='User')
+    def link_to_user(self, obj):
+        link = reverse('admin:user_customuser_change', args=[obj.user.id])
+        return format_html('<a href="{}">{}</a>', link, f'{obj.user.username} ({obj.user})')
+
+    def get_fieldsets(self, request, obj=None):
+        if not obj:
+            self.readonly_fields = []
+            return self.add_fieldset
+        self.readonly_fields = ('uuid', 'created_at',
+                                'updated_at', 'product', 'user',)
+        return super(ReviewAdmin, self).get_fieldsets(request, obj)
+
+
+admin.site.register(Review, ReviewAdmin)

--- a/server/review/admin.py
+++ b/server/review/admin.py
@@ -5,6 +5,44 @@ from django.utils.html import format_html
 from .models import Review
 
 
+# REVIEW INLINES
+class ViewReviewInline(admin.TabularInline):
+    """
+    Inline Model Admin for viewing the Review model.
+    """
+    model = Review
+    verbose_name = 'View Review'
+    verbose_name_plural = 'View Reviews'
+
+    extra = 0
+
+    fields = ('review', 'product', 'user', 'created_at', 'updated_at',)
+    readonly_fields = ('product', 'user', 'created_at', 'updated_at')
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
+class AddReviewInline(admin.TabularInline):
+    """
+    Inline Model Admin for adding to the Review model.
+    """
+    model = Review
+    verbose_name = 'Add Review'
+    verbose_name_plural = 'Add Reviews'
+
+    extra = 0
+    max_num = 1
+
+    fields = ('review', 'product', 'user',)
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return False
+
+
 # REVIEW ADMIN
 class ReviewAdmin(admin.ModelAdmin):
     """

--- a/server/review/models.py
+++ b/server/review/models.py
@@ -17,3 +17,6 @@ class Review(models.Model):
         'product.Product', related_name='reviews', on_delete=models.CASCADE)
     user = models.ForeignKey(
         'user.CustomUser', related_name='reviews', on_delete=models.CASCADE)
+
+    def __str__(self):
+        return f'{self.product} review by {self.user}'

--- a/server/review/models.py
+++ b/server/review/models.py
@@ -19,4 +19,4 @@ class Review(models.Model):
         'user.CustomUser', related_name='reviews', on_delete=models.CASCADE)
 
     def __str__(self):
-        return f'{self.product} review by {self.user}'
+        return f'{self.product} ({self.product.truck}) review by {self.user.username} ({self.user})'

--- a/server/user/admin.py
+++ b/server/user/admin.py
@@ -3,6 +3,7 @@ from django.contrib.auth.admin import UserAdmin
 from django.utils.html import format_html
 
 from .models import CustomUser
+from review.admin import AddReviewInline, ViewReviewInline
 
 
 # USER ADMIN
@@ -39,6 +40,9 @@ class CustomUserAdmin(UserAdmin):
         }),
     )
 
+    # To be viewed on the user since these models have a foreign key.
+    inlines = (AddReviewInline, ViewReviewInline,)
+
     # Adding preview image.
     def image_tag(self, obj):
         if obj.profile_image:
@@ -46,6 +50,17 @@ class CustomUserAdmin(UserAdmin):
         else:
             return '(No image)'
     image_tag.short_description = 'Preview'
+
+    # Even though the UserAdmin does this with the add_fieldsets out of the box than other
+    # admin models, this method still needs to be called to get rid of the inlines during
+    # the creation page.
+    def get_fieldsets(self, request, obj=None):
+        if not obj:
+            self.inlines = []
+            return self.add_fieldsets
+
+        self.inlines = (AddReviewInline, ViewReviewInline,)
+        return super(CustomUserAdmin, self).get_fieldsets(request, obj)
 
 
 admin.site.register(CustomUser, CustomUserAdmin)


### PR DESCRIPTION
## Changes
1. Created a model admin for the `Review` model called `ReviewAdmin`.
2. Created admin inlines called `ViewReviewInline` and `AddReviewInline` with the `Review` model, and embedded it to the `ProductAdmin` and `CustomUserAdmin`.

## Purpose
There needs to be a Review interface on the admin site.

## Approach
Similar to #91, #92, and #93. A `get_fieldsets` method was created in the `CustomUserAdmin` in order to remove the inlines in the creation page, but add it back in the creation/view page.

Closes #87 