### PR TITLE
Consistent API Output for Social with Permission Classes

### DIFF
--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -68,3 +68,12 @@ def error_500(request):
     })
 
     return response
+
+
+def final_success_response(response):
+    if not response.exception:
+        response.data = {
+            'statusCode': response.status_code,
+            'status': 'success',
+            'data': response.data,
+        }

--- a/server/social/views.py
+++ b/server/social/views.py
@@ -4,6 +4,8 @@ from rest_framework.permissions import AllowAny
 from .models import Emoji, Like
 from .serializers import EmojiSerializer, LikeSerializer
 
+from main.utils import final_success_response
+
 
 # Emoji views:
 class EmojiListAPIView(generics.ListAPIView):
@@ -17,12 +19,7 @@ class EmojiListAPIView(generics.ListAPIView):
     queryset = Emoji.objects.all()
 
     def finalize_response(self, request, response, *args, **kwargs):
-        if not response.exception:
-            response.data = {
-                'statusCode': response.status_code,
-                'status': 'success',
-                'data': response.data,
-            }
+        final_success_response(response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -41,12 +38,7 @@ class EmojiDetailAPIView(generics.RetrieveAPIView):
     lookup_field = 'uuid'
 
     def finalize_response(self, request, response, *args, **kwargs):
-        if not response.exception:
-            response.data = {
-                'statusCode': response.status_code,
-                'status': 'success',
-                'data': response.data,
-            }
+        final_success_response(response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -64,12 +56,7 @@ class LikeListCreateAPIView(generics.ListCreateAPIView):
     queryset = Like.objects.all()
 
     def finalize_response(self, request, response, *args, **kwargs):
-        if not response.exception:
-            response.data = {
-                'statusCode': response.status_code,
-                'status': 'success',
-                'data': response.data,
-            }
+        final_success_response(response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -88,11 +75,6 @@ class LikeDetailUpdateAPIView(generics.RetrieveUpdateAPIView):
     lookup_field = 'uuid'
 
     def finalize_response(self, request, response, *args, **kwargs):
-        if not response.exception:
-            response.data = {
-                'statusCode': response.status_code,
-                'status': 'success',
-                'data': response.data,
-            }
+        final_success_response(response)
 
         return super().finalize_response(request, response, *args, **kwargs)

--- a/server/social/views.py
+++ b/server/social/views.py
@@ -13,8 +13,8 @@ class EmojiListAPIView(generics.ListAPIView):
     Request Type: GET.
     """
     permission_classes = (AllowAny,)
-    queryset = Emoji.objects.all()
     serializer_class = EmojiSerializer
+    queryset = Emoji.objects.all()
 
     def finalize_response(self, request, response, *args, **kwargs):
         if not response.exception:
@@ -36,9 +36,9 @@ class EmojiDetailAPIView(generics.RetrieveAPIView):
     Request Type: GET.
     """
     permission_classes = (AllowAny,)
+    serializer_class = EmojiSerializer
     queryset = Emoji.objects.all()
     lookup_field = 'uuid'
-    serializer_class = EmojiSerializer
 
     def finalize_response(self, request, response, *args, **kwargs):
         if not response.exception:
@@ -60,8 +60,8 @@ class LikeListCreateAPIView(generics.ListCreateAPIView):
     Request Type: GET and POST.
     """
     permission_classes = (AllowAny,)
-    queryset = Like.objects.all()
     serializer_class = LikeSerializer
+    queryset = Like.objects.all()
 
     def finalize_response(self, request, response, *args, **kwargs):
         if not response.exception:
@@ -83,9 +83,9 @@ class LikeDetailUpdateAPIView(generics.RetrieveUpdateAPIView):
     Request Type: GET, PUT, and PATCH.
     """
     permission_classes = (AllowAny,)
+    serializer_class = LikeSerializer
     queryset = Like.objects.all()
     lookup_field = 'uuid'
-    serializer_class = LikeSerializer
 
     def finalize_response(self, request, response, *args, **kwargs):
         if not response.exception:

--- a/server/social/views.py
+++ b/server/social/views.py
@@ -1,4 +1,5 @@
 from rest_framework import generics
+from rest_framework.permissions import AllowAny
 
 from .models import Emoji, Like
 from .serializers import EmojiSerializer, LikeSerializer
@@ -11,8 +12,19 @@ class EmojiListAPIView(generics.ListAPIView):
 
     Request Type: GET.
     """
+    permission_classes = (AllowAny,)
     queryset = Emoji.objects.all()
     serializer_class = EmojiSerializer
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        if not response.exception:
+            response.data = {
+                'statusCode': response.status_code,
+                'status': 'success',
+                'data': response.data,
+            }
+
+        return super().finalize_response(request, response, *args, **kwargs)
 
 
 class EmojiDetailAPIView(generics.RetrieveAPIView):
@@ -23,9 +35,20 @@ class EmojiDetailAPIView(generics.RetrieveAPIView):
 
     Request Type: GET.
     """
+    permission_classes = (AllowAny,)
     queryset = Emoji.objects.all()
     lookup_field = 'uuid'
     serializer_class = EmojiSerializer
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        if not response.exception:
+            response.data = {
+                'statusCode': response.status_code,
+                'status': 'success',
+                'data': response.data,
+            }
+
+        return super().finalize_response(request, response, *args, **kwargs)
 
 
 # Like views:
@@ -36,8 +59,19 @@ class LikeListCreateAPIView(generics.ListCreateAPIView):
 
     Request Type: GET and POST.
     """
+    permission_classes = (AllowAny,)
     queryset = Like.objects.all()
     serializer_class = LikeSerializer
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        if not response.exception:
+            response.data = {
+                'statusCode': response.status_code,
+                'status': 'success',
+                'data': response.data,
+            }
+
+        return super().finalize_response(request, response, *args, **kwargs)
 
 
 class LikeDetailUpdateAPIView(generics.RetrieveUpdateAPIView):
@@ -48,6 +82,17 @@ class LikeDetailUpdateAPIView(generics.RetrieveUpdateAPIView):
 
     Request Type: GET, PUT, and PATCH.
     """
+    permission_classes = (AllowAny,)
     queryset = Like.objects.all()
     lookup_field = 'uuid'
     serializer_class = LikeSerializer
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        if not response.exception:
+            response.data = {
+                'statusCode': response.status_code,
+                'status': 'success',
+                'data': response.data,
+            }
+
+        return super().finalize_response(request, response, *args, **kwargs)


### PR DESCRIPTION
## Changes
1. For the `social` app, change the response to be consistent by utilizing the `finalize_response` method.
2. Created a custom function called `final_success_response` to reduce code and to be used in all other apps.

## Purpose
Not all of the output for the API for the `social` app are not consistent on different endpoints which could lead to confusion and frustration for the developers both in the Frontend and Backend. Also, there needs to be permission classes in the `social` views that allows anyone to have access.

Closes #114 