### PR TITLE
Consistent API Output for the Event app with Permission Classes

### DIFF
--- a/server/event/views.py
+++ b/server/event/views.py
@@ -1,7 +1,10 @@
 from rest_framework import generics
+from rest_framework.permissions import AllowAny
 
 from .models import Event
 from .serializers import EventSerializer
+
+from main.utils import final_success_response
 
 
 class EventListAPIView(generics.ListAPIView):
@@ -10,8 +13,14 @@ class EventListAPIView(generics.ListAPIView):
 
     Request Type: GET.
     """
-    queryset = Event.objects.all().order_by('date')
+    permission_classes = (AllowAny,)
     serializer_class = EventSerializer
+    queryset = Event.objects.all().order_by('date')
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        final_success_response(response)
+
+        return super().finalize_response(request, response, *args, **kwargs)
 
 
 class EventDetailAPIView(generics.RetrieveAPIView):
@@ -22,6 +31,12 @@ class EventDetailAPIView(generics.RetrieveAPIView):
 
     Request Type: GET.
     """
+    permission_classes = (AllowAny,)
+    serializer_class = EventSerializer
     queryset = Event.objects.all().order_by('date')
     lookup_field = 'uuid'
-    serializer_class = EventSerializer
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        final_success_response(response)
+
+        return super().finalize_response(request, response, *args, **kwargs)


### PR DESCRIPTION
## Changes
1. Added permissions to allow any user(s) to view the data.
2. Changed the output of the JSON for the `event` app so that it could be consistent with all other apps.

## Purpose
Not all of the output for the API for the `event` app are consistent on different endpoints which could lead to confusion or frustration for the developers both in the Frontend and Backend. Also, there needs to be permission classes in the `event` views that allows anyone to have access. No authentication is necessary for this app.

Closes #121 