### PR TITLE
Better Error Messages for Users in REST API

### DIFF
--- a/server/main/exceptions.py
+++ b/server/main/exceptions.py
@@ -10,7 +10,6 @@ def custom_exception_handler(exc, context):
     }
 
     response = exception_handler(exc, context)
-    print(exc)
 
     if response is not None:
         custom_response = {}

--- a/server/user/serializers.py
+++ b/server/user/serializers.py
@@ -126,7 +126,9 @@ class RegisterSerializer(serializers.ModelSerializer):
     username = serializers.CharField(required=True, min_length=4, max_length=25, validators=[
         UniqueValidator(queryset=CustomUser.objects.all(), message='This username already exists.')], error_messages={
             'required': 'The username is required.',
-            'blank': 'The username cannot be empty.'
+            'blank': 'The username cannot be empty.',
+            'min_length': 'The username should be no less than 4 characters.',
+            'max_length': 'The username should be no more than 25 characters.'
     })
     password = serializers.CharField(required=True, validators=[
         validate_password], error_messages={
@@ -178,7 +180,9 @@ class UserProfileSerializer(serializers.ModelSerializer):
     })
     username = serializers.CharField(required=False, min_length=4, max_length=25, validators=[
         UniqueValidator(queryset=CustomUser.objects.all(), message='This username already exists.')], error_messages={
-            'blank': 'The username cannot be empty.'
+            'blank': 'The username cannot be empty.',
+            'min_length': 'The username should be no less than 4 characters.',
+            'max_length': 'The username should be no more than 25 characters.'
     })
 
     class Meta:

--- a/server/user/serializers.py
+++ b/server/user/serializers.py
@@ -48,10 +48,11 @@ class ChangePasswordSerializer(serializers.ModelSerializer):
         old_password = data.get('password', None)
 
         if old_password is None:
-            raise serializers.ValidationError('Your old password is required.')
+            raise serializers.ValidationError('The old password is required.')
 
         if old_password != old_password_confirmation:
-            raise serializers.ValidationError('The passwords do not match.')
+            raise serializers.ValidationError(
+                'The old password and its confirmation do not match.')
 
         return old_password_confirmation
 
@@ -89,10 +90,10 @@ class LoginSerializer(serializers.ModelSerializer):
         password = data.get('password', None)
 
         if email is None:
-            raise serializers.ValidationError('An email is required.')
+            raise serializers.ValidationError('The email is required.')
 
         if password is None:
-            raise serializers.ValidationError('A password is required.')
+            raise serializers.ValidationError('The password is required.')
 
         user = authenticate(username=email, password=password)
 
@@ -119,12 +120,12 @@ class RegisterSerializer(serializers.ModelSerializer):
     Creates a new user.
     """
     email = serializers.EmailField(required=True, validators=[
-        UniqueValidator(queryset=CustomUser.objects.all(), message='This email already exists.')], error_messages={
+        UniqueValidator(queryset=CustomUser.objects.all(), message='The email already exists.')], error_messages={
             'required': 'The email is required.',
             'blank': 'The email cannot be empty.'
     })
     username = serializers.CharField(required=True, min_length=4, max_length=25, validators=[
-        UniqueValidator(queryset=CustomUser.objects.all(), message='This username already exists.')], error_messages={
+        UniqueValidator(queryset=CustomUser.objects.all(), message='The username already exists.')], error_messages={
             'required': 'The username is required.',
             'blank': 'The username cannot be empty.',
             'min_length': 'The username should be no less than 4 characters.',
@@ -175,11 +176,11 @@ class UserProfileSerializer(serializers.ModelSerializer):
     Changes the user's email and/or username.
     """
     email = serializers.EmailField(required=False, validators=[
-        UniqueValidator(queryset=CustomUser.objects.all(), message='This email already exists.')], error_messages={
+        UniqueValidator(queryset=CustomUser.objects.all(), message='The email already exists.')], error_messages={
             'blank': 'The email cannot be empty.'
     })
     username = serializers.CharField(required=False, min_length=4, max_length=25, validators=[
-        UniqueValidator(queryset=CustomUser.objects.all(), message='This username already exists.')], error_messages={
+        UniqueValidator(queryset=CustomUser.objects.all(), message='The username already exists.')], error_messages={
             'blank': 'The username cannot be empty.',
             'min_length': 'The username should be no less than 4 characters.',
             'max_length': 'The username should be no more than 25 characters.'

--- a/server/user/serializers.py
+++ b/server/user/serializers.py
@@ -14,12 +14,18 @@ class ChangePasswordSerializer(serializers.ModelSerializer):
 
     Changes the user's password.
     """
-    old_password = serializers.CharField(required=True, validators=[
-                                         validate_password], write_only=True)
-    old_password_confirmation = serializers.CharField(
-        required=True, validators=[validate_password], write_only=True)
-    new_password = serializers.CharField(required=True, validators=[
-                                         validate_password], write_only=True)
+    old_password = serializers.CharField(required=True, validators=[validate_password], error_messages={
+        'required': 'The old password is required.',
+        'blank': 'The old password cannot be empty.'
+    }, write_only=True)
+    old_password_confirmation = serializers.CharField(required=True, error_messages={
+        'required': 'The old password confirmation is required.',
+        'blank': 'The old password confirmation cannot be empty.'
+    }, write_only=True)
+    new_password = serializers.CharField(required=True, validators=[validate_password], error_messages={
+        'required': 'The new password is required.',
+        'blank': 'The new password cannot be empty.'
+    }, write_only=True)
 
     class Meta:
         model = CustomUser
@@ -64,9 +70,14 @@ class LoginSerializer(serializers.ModelSerializer):
 
     Logins the user.
     """
-    email = serializers.EmailField(required=True)
-    password = serializers.CharField(required=True, validators=[
-                                     validate_password], write_only=True)
+    email = serializers.EmailField(required=True, error_messages={
+        'required': 'The email is required.',
+        'blank': 'The email cannot be empty.'
+    })
+    password = serializers.CharField(required=True, validators=[validate_password], error_messages={
+        'required': 'The password is required.',
+        'blank': 'The password cannot be empty.'
+    }, write_only=True)
     token = serializers.CharField(max_length=255, read_only=True)
 
     class Meta:
@@ -108,13 +119,24 @@ class RegisterSerializer(serializers.ModelSerializer):
     Creates a new user.
     """
     email = serializers.EmailField(required=True, validators=[
-                                   UniqueValidator(queryset=CustomUser.objects.all(), message='This email already exists.')])
+        UniqueValidator(queryset=CustomUser.objects.all(), message='This email already exists.')], error_messages={
+            'required': 'The email is required.',
+            'blank': 'The email cannot be empty.'
+    })
     username = serializers.CharField(required=True, min_length=4, max_length=25, validators=[
-                                     UniqueValidator(queryset=CustomUser.objects.all(), message='This username already exists.')])
+        UniqueValidator(queryset=CustomUser.objects.all(), message='This username already exists.')], error_messages={
+            'required': 'The username is required.',
+            'blank': 'The username cannot be empty.'
+    })
     password = serializers.CharField(required=True, validators=[
-                                     validate_password], write_only=True)
-    password_confirmation = serializers.CharField(
-        required=True, write_only=True)
+        validate_password], error_messages={
+            'required': 'The password is required.',
+            'blank': 'The password cannot be empty.'
+    }, write_only=True)
+    password_confirmation = serializers.CharField(required=True, error_messages={
+        'required': 'The password confirmation is required.',
+        'blank': 'The password confirmation cannot be empty.'
+    }, write_only=True)
     token = serializers.CharField(max_length=255, read_only=True)
 
     class Meta:
@@ -150,10 +172,14 @@ class UserProfileSerializer(serializers.ModelSerializer):
 
     Changes the user's email and/or username.
     """
-    email = serializers.EmailField(required=False, validators=[UniqueValidator(
-        queryset=CustomUser.objects.all(), message='This email already exists.')])
+    email = serializers.EmailField(required=False, validators=[
+        UniqueValidator(queryset=CustomUser.objects.all(), message='This email already exists.')], error_messages={
+            'blank': 'The email cannot be empty.'
+    })
     username = serializers.CharField(required=False, min_length=4, max_length=25, validators=[
-                                     UniqueValidator(queryset=CustomUser.objects.all(), message='This username already exists.')])
+        UniqueValidator(queryset=CustomUser.objects.all(), message='This username already exists.')], error_messages={
+            'blank': 'The username cannot be empty.'
+    })
 
     class Meta:
         model = CustomUser

--- a/server/user/views.py
+++ b/server/user/views.py
@@ -119,7 +119,7 @@ class UserProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
-    def update(self, request, *args, **kwargs):
+    def partial_update(self, request, *args, **kwargs):
         serializer = self.serializer_class(
             instance=request.user, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)

--- a/server/user/views.py
+++ b/server/user/views.py
@@ -7,6 +7,8 @@ from rest_framework.views import APIView
 from .renderers import UserJSONRenderer
 from .serializers import ChangePasswordSerializer, LoginSerializer, RegisterSerializer, UserProfileSerializer
 
+from main.utils import final_success_response
+
 
 class ChangePasswordUpdateAPIView(UpdateAPIView):
     """
@@ -24,19 +26,18 @@ class ChangePasswordUpdateAPIView(UpdateAPIView):
     renderer_classes = (UserJSONRenderer,)
     serializer_class = ChangePasswordSerializer
 
+    def finalize_response(self, request, response, *args, **kwargs):
+        final_success_response(response)
+
+        return super().finalize_response(request, response, *args, **kwargs)
+
     def update(self, request, *args, **kwargs):
         serializer = self.serializer_class(
             instance=request.user, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
-        data = {
-            'statusCode': status.HTTP_200_OK,
-            'status': 'success',
-            'data': serializer.data,
-        }
-
-        return Response(data=data, status=status.HTTP_200_OK)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
 
 
 class LoginAPIView(APIView):
@@ -55,17 +56,16 @@ class LoginAPIView(APIView):
     renderer_classes = (UserJSONRenderer,)
     serialzer_class = LoginSerializer
 
+    def finalize_response(self, request, response, *args, **kwargs):
+        final_success_response(response)
+
+        return super().finalize_response(request, response, *args, **kwargs)
+
     def post(self, request):
         serializer = self.serialzer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        data = {
-            'statusCode': status.HTTP_200_OK,
-            'status': 'success',
-            'data': serializer.data,
-        }
-
-        return Response(data=data, status=status.HTTP_200_OK)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
 
 
 class RegisterAPIView(APIView):
@@ -84,18 +84,17 @@ class RegisterAPIView(APIView):
     renderer_classes = (UserJSONRenderer,)
     serializer_class = RegisterSerializer
 
+    def finalize_response(self, request, response, *args, **kwargs):
+        final_success_response(response)
+
+        return super().finalize_response(request, response, *args, **kwargs)
+
     def post(self, request):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
-        data = {
-            'statusCode': status.HTTP_201_CREATED,
-            'status': 'success',
-            'data': serializer.data,
-        }
-
-        return Response(data=data, status=status.HTTP_201_CREATED)
+        return Response(data=serializer.data, status=status.HTTP_201_CREATED)
 
 
 class UserProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
@@ -114,6 +113,11 @@ class UserProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
     renderer_classes = (UserJSONRenderer,)
     serializer_class = UserProfileSerializer
 
+    def finalize_response(self, request, response, *args, **kwargs):
+        final_success_response(response)
+
+        return super().finalize_response(request, response, *args, **kwargs)
+
     def retrieve(self, request, *args, **kwargs):
         serializer = self.serializer_class(request.user)
 
@@ -125,10 +129,4 @@ class UserProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
-        data = {
-            'statusCode': status.HTTP_200_OK,
-            'status': 'success',
-            'data': serializer.data,
-        }
-
-        return Response(data=data, status=status.HTTP_200_OK)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Changes
1. Changed some of the error messages to be more readable for the users/developers.
2. Used `finalize_response` to reduce redundancy on the Response output.

## Purpose
Some of the error messages for the `user` app needs to be clearer on what is wrong.

Closes #128 