### PR TITLE
Epic Issue Template and Codeowners for `.github/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BlackCubes

--- a/.github/ISSUE_TEMPLATE/epic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-issue-template.md
@@ -1,0 +1,26 @@
+---
+name: Epic Issue Template
+about: Issue template used for Epics
+title: ""
+labels: Epic
+---
+
+## Desired Feature
+
+A clear and concise description of what the feature is and what it does.
+
+## Actual/Current Behavior
+
+A clear and concise description of what is currently happening.
+
+## Steps to Implement
+
+Add a list of the steps required to implement this feature
+
+## Epic Checklist
+
+Add a list of issues related to this epic
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## Changes
1. Created CODEOWNERS and epic-issue-template files.

## Purpose
There should be an Epic Issue Template and Codeowners inside the `.github/` folder in order to handle big issues and describe who owns the code.

Closes #133 