### PR TITLE
Create Review API with RTK

### DIFF
--- a/web/src/common/api/reviewApi.ts
+++ b/web/src/common/api/reviewApi.ts
@@ -1,0 +1,61 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import customBaseQuery from './customBaseQuery';
+import { Review } from '../models';
+
+export const reviewApi = createApi({
+  reducerPath: 'reviewApi',
+  baseQuery: customBaseQuery,
+
+  keepUnusedDataFor: 0,
+  refetchOnMountOrArgChange: true,
+  refetchOnReconnect: true,
+
+  tagTypes: ['Review'],
+
+  endpoints: (builder) => ({
+    getReviews: builder.query<Review[], void>({
+      query: () => ({ url: '/reviews' }),
+      providesTags: ['Review'],
+    }),
+
+    getReviewByUuid: builder.query<Review, string>({
+      query: (uuid) => ({ url: `/reviews/${uuid}` }),
+      providesTags: ['Review'],
+    }),
+
+    createReview: builder.mutation<Review, Pick<Review, 'review' | 'product'>>({
+      query: (payload) => ({
+        url: '/reviews',
+        method: 'POST',
+        body: payload,
+      }),
+      invalidatesTags: ['Review'],
+    }),
+
+    updateReview: builder.mutation<Review, Pick<Review, 'uuid' | 'review'>>({
+      query: ({ uuid, review }) => ({
+        url: `/reviews/${uuid}`,
+        method: 'PATCH',
+        body: { review },
+      }),
+      invalidatesTags: ['Review'],
+    }),
+
+    deleteReview: builder.mutation<void, string>({
+      query: (uuid) => ({
+        url: `/reviews/${uuid}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['Review'],
+    }),
+  }),
+});
+
+export const {
+  useCreateReviewMutation,
+  useDeleteReviewMutation,
+  useGetReviewsQuery,
+  useGetReviewByUuidQuery,
+  useUpdateReviewMutation,
+} = reviewApi;

--- a/web/src/common/models/index.ts
+++ b/web/src/common/models/index.ts
@@ -1,1 +1,2 @@
 export * from './event';
+export * from './review';

--- a/web/src/common/models/review.ts
+++ b/web/src/common/models/review.ts
@@ -1,0 +1,8 @@
+export interface Review {
+  uuid: string;
+  review: string;
+  created_at: string;
+  updated_at: string;
+  product: string;
+  user: string;
+}


### PR DESCRIPTION
## Changes
1. Created a type interface to be used for the Review RTK.
2. Created an RTK functionality on fetching the `review` API endpoint to be used throughout the Web app.

## Purpose
There should be an RTK API that gets the `review` from the Django server.

Closes #139 