### PR TITLE
Changed the Event Serializer Inheritance

### DIFF
--- a/server/event/serializers.py
+++ b/server/event/serializers.py
@@ -5,7 +5,7 @@ from .models import Event
 from foodtruck.models import Truck
 
 
-class EventSerializer(serializers.Serializer):
+class EventSerializer(serializers.ModelSerializer):
     """
     Serializer on the Event model.
 

--- a/server/event/serializers.py
+++ b/server/event/serializers.py
@@ -1,4 +1,3 @@
-from django.db.models import fields
 from rest_framework import serializers
 
 from .models import Event


### PR DESCRIPTION
## Changes
1. Changed the inheritance for the `EventSerializer` from `Serializer` to `ModelSerializer` in order to return all of the `fields` in the `Meta` class.

## Purpose
When there is a response for the `event` app in Django, it should display the results that was setup from the `fields` in the `Meta` class. Yet, this does not happen since the `EventSerializer` is inheriting the `Serializer` which only outputs the truck field.

Closes #157 