### PR TITLE
Added Context to `ChangePasswordUpdateAPIView`

### DIFF
--- a/server/user/views.py
+++ b/server/user/views.py
@@ -33,7 +33,7 @@ class ChangePasswordUpdateAPIView(UpdateAPIView):
 
     def update(self, request, *args, **kwargs):
         serializer = self.serializer_class(
-            instance=request.user, data=request.data, partial=True)
+            instance=request.user, context={'request': request}, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
 


### PR DESCRIPTION
## Changes
1. Added context dictionary with `request` as both key and value in `ChangePasswordUpdateAPIView` in order for the logic in the serializer to get that context.

## Purpose
When the user changes their password, it should run smoothly without any developer bugs. Yet, since we are manually using the `update` method in `ChangePasswordUpdateAPIView`, the context is not set manually. This would mean the logic in our serializer for this APIView would throw an error since it is expecting a `request` in the context dictionary.

Closes #159 