### PR TITLE
Fixed Correct Dictionary Key to Get the `old_password`

### DIFF
--- a/server/user/serializers.py
+++ b/server/user/serializers.py
@@ -45,7 +45,7 @@ class ChangePasswordSerializer(serializers.ModelSerializer):
     def validate_old_password_confirmation(self, old_password_confirmation):
         data = self.get_initial()
 
-        old_password = data.get('password', None)
+        old_password = data.get('old_password', None)
 
         if old_password is None:
             raise serializers.ValidationError('The old password is required.')


### PR DESCRIPTION
## Changes
1. Changed the correct key to get from the dictionary.

## Purpose
On line 48 in `ChangePasswordSerializer` in the file `user/serializers.py`, the key in the data dictionary to get should be `old_password`.

Closes #161 