### PR TITLE
Removed Update Feature for `LikeDetailUpdateAPIView`

### DIFF
--- a/server/social/urls.py
+++ b/server/social/urls.py
@@ -5,7 +5,7 @@ from . import views
 
 urlpatterns = [
     path('', views.LikeListCreateAPIView.as_view()),
-    path('<uuid:uuid>', views.LikeDetailUpdateAPIView.as_view()),
+    path('<uuid:uuid>', views.LikeDetailAPIView.as_view()),
     path('emojis/', views.EmojiListAPIView.as_view()),
     path('emojis/<uuid:uuid>', views.EmojiDetailAPIView.as_view()),
 ]

--- a/server/social/views.py
+++ b/server/social/views.py
@@ -61,13 +61,13 @@ class LikeListCreateAPIView(generics.ListCreateAPIView):
         return super().finalize_response(request, response, *args, **kwargs)
 
 
-class LikeDetailUpdateAPIView(generics.RetrieveUpdateAPIView):
+class LikeDetailAPIView(generics.RetrieveAPIView):
     """
-    API view to retrieve or update from the Like model based on its uuid.
+    API view to retrieve the Like model based on its uuid.
 
     Lookup Field: uuid.
 
-    Request Type: GET, PUT, and PATCH.
+    Request Type: GET.
     """
     permission_classes = (AllowAny,)
     serializer_class = LikeSerializer


### PR DESCRIPTION
## Changes
1. Removed the update portion for `LikeDetailUpdateAPIView` so it could only retrieve, and changed the class name and the docs to better reflect this.

## Purpose
There should be no updating on the `LikeDetailUpdateAPIView`, but it should only be for details.

Closes #167 