### PR TITLE
Remove the events and products fields in `TruckSerializer`

### DIFF
--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -1,8 +1,6 @@
 from rest_framework import serializers
 
 from .models import Truck, TruckImage
-from event.serializers import EventSerializer
-from product.serializers import ProductSerializer
 
 
 class TruckImageSerializer(serializers.ModelSerializer):
@@ -30,12 +28,10 @@ class TruckSerializer(serializers.ModelSerializer):
     Fields: uuid, name, slug, info, phone_number, email, website, products, images,
     and events.
     """
-    products = ProductSerializer(many=True, read_only=True)
     images = TruckImageSerializer(many=True, read_only=True)
-    events = EventSerializer(many=True, read_only=True)
 
     class Meta:
         model = Truck
         lookup_field = 'slug'
         fields = ('uuid', 'name', 'slug', 'info', 'phone_number',
-                  'email', 'website', 'products', 'images', 'events',)
+                  'email', 'website', 'images',)


### PR DESCRIPTION
## Changes
1. Removed the `events` and `products` fields in the `TruckSerializer` to keep the JSON output simple.

## Purpose
The fields of `events` and `products` in the `TruckSerializer` are not needed as it creates unneeded deep nesting, and it is redundant since there is already an API URL to get all products and events based on the foodtruck's slug.

Closes #170 