### PR TITLE
Extended and Refactored the Product API (Non-Nested Routes)

### DIFF
--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -32,8 +32,42 @@ class TruckSerializer(DynamicFieldsModelSerializer):
     """
     images = TruckImageSerializer(many=True, read_only=True)
 
+    want_profile_image = False
+
     class Meta:
         model = Truck
         lookup_field = 'slug'
         fields = ('uuid', 'name', 'slug', 'info', 'phone_number',
                   'email', 'website', 'images',)
+
+    def __init__(self, *args, **kwargs):
+        # An error would occur if this is not popped.
+        extra_fields = kwargs.pop('extra_fields', None)
+
+        # This is a safety check if `images` is in fields.
+        fields = kwargs.get('fields', None)
+
+        if extra_fields is not None and fields is not None:
+            self.want_profile_image = 'profile_image' in extra_fields and 'images' in fields
+
+        super(TruckSerializer, self).__init__(*args, **kwargs)
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        if self.want_profile_image:
+            profile_image = None
+
+            if not representation['images']:
+                profile_image = None
+            else:
+                for image_fields in representation['images']:
+                    if image_fields['is_profile_image']:
+                        profile_image = image_fields['image']
+                        break
+
+            representation.pop('images')
+
+            representation['profile_image'] = profile_image
+
+        return representation

--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -5,50 +5,22 @@ from .models import Truck, TruckImage
 from main.utils import DynamicFieldsModelSerializer
 
 
-class TruckImageSerializer(serializers.ModelSerializer):
+class GetTruckProfileImageDynamicSerializer(DynamicFieldsModelSerializer):
     """
-    Serializer on the TruckImage model.
+    A DynamicSerializer that gets the Foodtruck's profile image.
 
-    Lookup Field: slug.
-
-    Fields: uuid, image, is_profile_image, and truck.
-    """
-    truck = serializers.CharField(source='truck.slug')
-
-    class Meta:
-        model = TruckImage
-        lookup_field = 'uuid'
-        fields = ('uuid', 'image', 'is_profile_image', 'truck',)
-
-
-class TruckSerializer(DynamicFieldsModelSerializer):
-    """
-    Serializer on the Truck model. If the `profile_image` is required, then when
-    initializing this serializer, add in `fields` with `images` and `extra_fields`
-    with `profile_image` as kwargs:
+    If the `profile_image` is required, then when initializing the `TruckSerializer`,
+    add in `fields` with `images` and `extra_fields` with `profile_image` as kwargs:
         `TruckSerializer(fields=('images',), extra_fields=('profile_image',))`.
 
     The `__init__` method is used to check if both `profile_image` and `images` are
     in the `extra_fields` and `fields` (respectively) to get the Truck's profile image
-    in `to_representation`.
+    in the `to_representation` method.
 
     The `to_representation` method is used to actually get the Truck's profile image, and
     set it in the JSON response while removing the `images` output.
-
-    Lookup Field: slug.
-
-    Fields: uuid, name, slug, info, phone_number, email, website, products, images,
-    and events.
     """
-    images = TruckImageSerializer(many=True, read_only=True)
-
     want_profile_image = False
-
-    class Meta:
-        model = Truck
-        lookup_field = 'slug'
-        fields = ('uuid', 'name', 'slug', 'info', 'phone_number',
-                  'email', 'website', 'images',)
 
     def __init__(self, *args, **kwargs):
         # An error would occur if this is not popped.
@@ -60,7 +32,8 @@ class TruckSerializer(DynamicFieldsModelSerializer):
         if extra_fields is not None and fields is not None:
             self.want_profile_image = 'profile_image' in extra_fields and 'images' in fields
 
-        super(TruckSerializer, self).__init__(*args, **kwargs)
+        super(GetTruckProfileImageDynamicSerializer,
+              self).__init__(*args, **kwargs)
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
@@ -81,3 +54,40 @@ class TruckSerializer(DynamicFieldsModelSerializer):
             representation['profile_image'] = profile_image
 
         return representation
+
+
+class TruckImageSerializer(serializers.ModelSerializer):
+    """
+    Serializer on the TruckImage model.
+
+    Lookup Field: slug.
+
+    Fields: uuid, image, is_profile_image, and truck.
+    """
+    truck = serializers.CharField(source='truck.slug')
+
+    class Meta:
+        model = TruckImage
+        lookup_field = 'uuid'
+        fields = ('uuid', 'image', 'is_profile_image', 'truck',)
+
+
+class TruckSerializer(GetTruckProfileImageDynamicSerializer):
+    """
+    Serializer on the Truck model. If the `profile_image` is required, then when
+    initializing this serializer, add in `fields` with `images` and `extra_fields`
+    with `profile_image` as kwargs:
+        `TruckSerializer(fields=('images',), extra_fields=('profile_image',))`.
+
+    Lookup Field: slug.
+
+    Fields: uuid, name, slug, info, phone_number, email, website, products, images,
+    and events.
+    """
+    images = TruckImageSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Truck
+        lookup_field = 'slug'
+        fields = ('uuid', 'name', 'slug', 'info', 'phone_number',
+                  'email', 'website', 'images',)

--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -23,7 +23,17 @@ class TruckImageSerializer(serializers.ModelSerializer):
 
 class TruckSerializer(DynamicFieldsModelSerializer):
     """
-    Serializer on the Truck model.
+    Serializer on the Truck model. If the `profile_image` is required, then when
+    initializing this serializer, add in `fields` with `images` and `extra_fields`
+    with `profile_image` as kwargs:
+        `TruckSerializer(fields=('images',), extra_fields=('profile_image',))`.
+
+    The `__init__` method is used to check if both `profile_image` and `images` are
+    in the `extra_fields` and `fields` (respectively) to get the Truck's profile image
+    in `to_representation`.
+
+    The `to_representation` method is used to actually get the Truck's profile image, and
+    set it in the JSON response while removing the `images` output.
 
     Lookup Field: slug.
 

--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -2,6 +2,8 @@ from rest_framework import serializers
 
 from .models import Truck, TruckImage
 
+from main.utils import DynamicFieldsModelSerializer
+
 
 class TruckImageSerializer(serializers.ModelSerializer):
     """
@@ -19,7 +21,7 @@ class TruckImageSerializer(serializers.ModelSerializer):
         fields = ('uuid', 'image', 'is_profile_image', 'truck',)
 
 
-class TruckSerializer(serializers.ModelSerializer):
+class TruckSerializer(DynamicFieldsModelSerializer):
     """
     Serializer on the Truck model.
 

--- a/server/product/serializers.py
+++ b/server/product/serializers.py
@@ -14,7 +14,8 @@ class ProductSerializer(serializers.ModelSerializer):
     Fields: uuid, name, slug, info, image, price, quantity, is_available, truck,
     reviews, and likes.
     """
-    truck = TruckSerializer(fields=('uuid', 'name', 'slug',))
+    truck = TruckSerializer(
+        fields=('uuid', 'name', 'slug', 'images',), extra_fields=('profile_image',))
 
     class Meta:
         model = Product

--- a/server/product/serializers.py
+++ b/server/product/serializers.py
@@ -1,8 +1,6 @@
 from rest_framework import serializers
 
 from .models import Product
-from review.serializers import ReviewSerializer
-from social.serializers import LikeSerializer
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -15,11 +13,9 @@ class ProductSerializer(serializers.ModelSerializer):
     reviews, and likes.
     """
     truck = serializers.CharField(source='truck.slug')
-    likes = LikeSerializer(many=True, read_only=True)
-    reviews = ReviewSerializer(many=True, read_only=True)
 
     class Meta:
         model = Product
         lookup_field = 'slug'
         fields = ('uuid', 'name', 'slug', 'info', 'image', 'price',
-                  'quantity', 'is_available', 'truck', 'likes', 'reviews',)
+                  'quantity', 'is_available', 'truck',)

--- a/server/product/serializers.py
+++ b/server/product/serializers.py
@@ -2,6 +2,8 @@ from rest_framework import serializers
 
 from .models import Product
 
+from foodtruck.serializers import TruckSerializer
+
 
 class ProductSerializer(serializers.ModelSerializer):
     """
@@ -12,7 +14,7 @@ class ProductSerializer(serializers.ModelSerializer):
     Fields: uuid, name, slug, info, image, price, quantity, is_available, truck,
     reviews, and likes.
     """
-    truck = serializers.CharField(source='truck.slug')
+    truck = TruckSerializer(fields=('uuid', 'name', 'slug',))
 
     class Meta:
         model = Product


### PR DESCRIPTION
## Changes
1. Removed the `likes` and `reviews` fields in the `ProductSerializer` to keep the JSON output simple and not some crazy nested objects, and there are already nested URL routes to get them.
2. Created a custom class serializer called `DynamicFieldsModelSerializer` to add fields that are wanted as a JSON output, and add it as an inheritance to the `TruckSerializer`.
3. Dynamically added the Foodtruck's profile image to the JSON output if the developer requires it for the `TruckSerializer`.

## Purpose
The `likes` and `reviews` fields are not needed as it creates unneeded deep nesting, and it is redundant since there is already an API URL to get all likes (socials) and reviews based on the product's slug.

Lastly, extend the truck field where it returns an array of objects with keys of `name`, `slug`, `uuid`, and `profileImage` where the `profileImage` should only return the foodtruck's profile image. If there are no profile image, then set it to null.

Closes #171 