### PR TITLE
Extended the Social API

### DIFF
--- a/server/product/serializers.py
+++ b/server/product/serializers.py
@@ -1,11 +1,11 @@
+from rest_framework import serializers
+
 from .models import Product
 
 from foodtruck.serializers import TruckSerializer
 
-from main.utils import DynamicFieldsModelSerializer
 
-
-class ProductSerializer(DynamicFieldsModelSerializer):
+class ProductSerializer(serializers.ModelSerializer):
     """
     Serializer on the Product model.
 

--- a/server/product/serializers.py
+++ b/server/product/serializers.py
@@ -1,5 +1,3 @@
-from rest_framework import serializers
-
 from .models import Product
 
 from foodtruck.serializers import TruckSerializer

--- a/server/product/serializers.py
+++ b/server/product/serializers.py
@@ -4,8 +4,10 @@ from .models import Product
 
 from foodtruck.serializers import TruckSerializer
 
+from main.utils import DynamicFieldsModelSerializer
 
-class ProductSerializer(serializers.ModelSerializer):
+
+class ProductSerializer(DynamicFieldsModelSerializer):
     """
     Serializer on the Product model.
 

--- a/server/social/serializers.py
+++ b/server/social/serializers.py
@@ -1,7 +1,36 @@
 from rest_framework import serializers
 
 from .models import Emoji, Like
+
 from product.models import Product
+
+
+class LikeRepresentationModelSerializer(serializers.ModelSerializer):
+    """
+    A ModelSerializer that transforms the `emoji` and `product` fields to return
+    objects for better description. In the `LikeSerializer`, the fields (not the
+    `fields` in `Meta`) of `emoji` and `product` have a relational serializer field
+    which is the `SlugRelatedField`, and this would have an affect on both fields
+    to return the `slug_field` parameter. This leads to less description. The
+    solution is to simply implement the `to_representation` method.
+    """
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        representation['emoji'] = {
+            'uuid': instance.emoji.uuid,
+            'emoji': instance.emoji.emoji,
+            'name': instance.emoji.name,
+        }
+
+        representation['product'] = {
+            'uuid': instance.product.uuid,
+            'name': instance.product.name,
+            'slug': instance.product.slug,
+        }
+
+        return representation
 
 
 class EmojiSerializer(serializers.ModelSerializer):
@@ -18,7 +47,7 @@ class EmojiSerializer(serializers.ModelSerializer):
         fields = ('uuid', 'emoji', 'name',)
 
 
-class LikeSerializer(serializers.ModelSerializer):
+class LikeSerializer(LikeRepresentationModelSerializer):
     """
     Serializer on the Like model.
 


### PR DESCRIPTION
## Changes
1. Changed the JSON output for the `LikeSerializer` to return an object instead of strings for the `emoji` and `product` fields for better description.

## Purpose
When the user goes to the route of `/api/v1/socials/`, the fields for `emoji` and `product` should return clearer values than strings of an emoji icon and a product's slug. This is vague and should be better.

Closes #174 