### PR TITLE
Extended the `product` Field for the Review API

### DIFF
--- a/server/review/serializers.py
+++ b/server/review/serializers.py
@@ -32,3 +32,17 @@ class ReviewSerializer(serializers.ModelSerializer):
         lookup_field = 'uuid'
         fields = ('uuid', 'review', 'created_at',
                   'updated_at', 'product', 'user',)
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        product_image = None if not instance.product.image else instance.product.image
+
+        representation['product'] = {
+            'uuid': str(instance.product.uuid),
+            'name': instance.product.name,
+            'slug': instance.product.slug,
+            'image': product_image,
+        }
+
+        return representation


### PR DESCRIPTION
## Changes
1. Changed the JSON output for the `product` field in the `ReviewSerializer` so it could be better descriptive.

## Purpose
The `product` field should be extended where it should not return just a string of the product's slug. It should have better detail and return an object with keys of `name`, `slug`, `uuid`, and `image`.

Closes #172 