### PR TITLE
Removed the `user` Property on `/my-reviews/` route for Authenticated Users

### DIFF
--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -1,8 +1,17 @@
 import random
 import string
-from django.utils.text import slugify
 from django.http import JsonResponse
+from django.urls import resolve
+from django.utils.text import slugify
 from rest_framework import serializers
+
+
+def get_request_url_name(request_path):
+    """
+    Gets the URL name from the `urlpatterns`. If there are no URL name, then
+    it returns `None`.
+    """
+    return resolve(request_path).url_name
 
 
 def random_string_generator(size=10, chars=string.ascii_lowercase + string.digits):

--- a/server/review/serializers.py
+++ b/server/review/serializers.py
@@ -1,7 +1,11 @@
 from rest_framework import serializers
 
 from .models import Review
+
+from main.utils import get_request_url_name
+
 from product.models import Product
+
 from user.models import CustomUser
 
 
@@ -36,6 +40,17 @@ class ReviewSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         representation = super().to_representation(instance)
 
+        # This is to check if the it is on the route `/api/v1/reviews/my-reviews/`
+        is_auth_user_reviews_route = self.context['request'].method == 'GET' and get_request_url_name(
+            self.context['request'].path) == 'my-reviews'
+
+        if is_auth_user_reviews_route:
+            # If it is in the route `/api/v1/reviews/my-reviews/`, then remove
+            # the `user` key since this route shows all reviews made by the
+            # current authenticated user (removes redundancy).
+            representation.pop('user')
+
+        # Checks to see if the `image` field is not empty, or else it won't serialize.
         product_image = None if not instance.product.image else instance.product.image
 
         representation['product'] = {

--- a/server/review/urls.py
+++ b/server/review/urls.py
@@ -6,5 +6,5 @@ from . import views
 urlpatterns = [
     path('', views.ReviewListCreateAPIView.as_view()),
     path('<uuid:uuid>', views.ReviewDetailUpdateDeleteAPIView.as_view()),
-    path('my-reviews', views.ReviewListAPIView.as_view()),
+    path('my-reviews', views.ReviewListAPIView.as_view(), name='my-reviews'),
 ]


### PR DESCRIPTION
## Changes
1. Created a custom function called `get_request_url_name` to get the URL name from `urlpatterns`.
2. Removed the `user` property from the JSON output on the `/my-reviews/` route to get all reviews for current authenticated user to avoid redundancy.

## Purpose
When the user is logged in and retrieves their reviews they had created, the `user` field should not be shown since this is redundant.

Closes #173 