### PR TITLE
Removed `truck` From JSON Output on Getting All Products From Foodtruck

### DIFF
--- a/server/event/urls.py
+++ b/server/event/urls.py
@@ -3,7 +3,9 @@ from django.urls import path
 from . import views
 
 
+app_name = 'events'
+
 urlpatterns = [
-    path('', views.EventListAPIView.as_view()),
-    path('<uuid:uuid>', views.EventDetailAPIView.as_view()),
+    path('', views.EventListAPIView.as_view(), name='list'),
+    path('<uuid:uuid>', views.EventDetailAPIView.as_view(), name='detail'),
 ]

--- a/server/foodtruck/urls.py
+++ b/server/foodtruck/urls.py
@@ -2,13 +2,16 @@ from django.urls import path, re_path
 
 from . import views
 
+
+app_name = 'foodtrucks'
+
 urlpatterns = [
-    path('', views.TruckListAPIView.as_view()),
-    path('<slug:slug>', views.TruckDetailAPIView.as_view()),
+    path('', views.TruckListAPIView.as_view(), name='list'),
+    path('<slug:slug>', views.TruckDetailAPIView.as_view(), name='detail'),
     re_path(r'^(?P<truck_slug>[\w-]+)/products/?$',
-            views.TruckProductsModelViewSet.as_view({'get': 'list'})),
+            views.TruckProductsModelViewSet.as_view({'get': 'list'}), name='product-list'),
     re_path(r'^(?P<truck_slug>[\w-]+)/reviews/?$',
-            views.TruckReviewsModelViewSet.as_view({'get': 'list'})),
+            views.TruckReviewsModelViewSet.as_view({'get': 'list'}), name='review-list'),
     re_path(r'^(?P<truck_slug>[\w-]+)/socials/?$',
-            views.TruckLikesModelViewSet.as_view({'get': 'list'})),
+            views.TruckLikesModelViewSet.as_view({'get': 'list'}), name='social-list'),
 ]

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -14,6 +14,28 @@ def get_request_url_name(request_path):
     return resolve(request_path).url_name
 
 
+def get_request_view_name(request_path):
+    """
+    Gets the name of the view that matches the URL, including the namespace if
+    there is one.
+
+    If both `app_name` (or namespace) and the URL name from the `urlpatterns`
+    are provided in `urls.py`, then the output would be `app_name:url_name`.
+
+    If only the URL name from the `urlpatterns` is provided in `urls.py`, then
+    the output would be `url_name`.
+
+    WEIRD CASES:
+
+    If the `app_name` (or namespace) is provided in `urls.py` with no URL name,
+    then the output would be `app_name:app.views.SomeViewSet`.
+
+    If there are no `app_name` (or namespace) and URL name from the `urlpatterns`,
+    then the output would be `app.views.SomeViewSet`.
+    """
+    return resolve(request_path).view_name
+
+
 def random_string_generator(size=10, chars=string.ascii_lowercase + string.digits):
     """
     Generates a random string.

--- a/server/product/serializers.py
+++ b/server/product/serializers.py
@@ -4,6 +4,8 @@ from .models import Product
 
 from foodtruck.serializers import TruckSerializer
 
+from main.utils import get_request_view_name
+
 
 class ProductSerializer(serializers.ModelSerializer):
     """
@@ -22,3 +24,18 @@ class ProductSerializer(serializers.ModelSerializer):
         lookup_field = 'slug'
         fields = ('uuid', 'name', 'slug', 'info', 'image', 'price',
                   'quantity', 'is_available', 'truck',)
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        # This is to check if it is on the route `/api/v1/foodtrucks/<slug>/products/`.
+        is_products_in_foodtruck_route = get_request_view_name(
+            self.context['request'].path) == 'foodtrucks:product-list'
+
+        if is_products_in_foodtruck_route:
+            # If it is in the route `/api/v1/foodtrucks/<slug>/products/`, then remove
+            # the `truck` key since this route shows all products from the foodtruck
+            # (removes redundancy).
+            representation.pop('truck')
+
+        return representation

--- a/server/product/urls.py
+++ b/server/product/urls.py
@@ -3,11 +3,13 @@ from django.urls import path, re_path
 from . import views
 
 
+app_name = 'products'
+
 urlpatterns = [
-    path('', views.ProductListAPIView.as_view()),
-    path('<slug:slug>', views.ProductDetailAPIView.as_view()),
+    path('', views.ProductListAPIView.as_view(), name='list'),
+    path('<slug:slug>', views.ProductDetailAPIView.as_view(), name='detail'),
     re_path(r'^(?P<product_slug>[\w-]+)/reviews/?$',
-            views.ProductReviewsModelViewSet.as_view({'get': 'list'})),
+            views.ProductReviewsModelViewSet.as_view({'get': 'list'}), name='review-list'),
     re_path(r'^(?P<product_slug>[\w-]+)/socials/?$',
-            views.ProductLikesModelViewSet.as_view({'get': 'list'})),
+            views.ProductLikesModelViewSet.as_view({'get': 'list'}), name='social-list'),
 ]

--- a/server/review/serializers.py
+++ b/server/review/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from .models import Review
 
-from main.utils import get_request_url_name
+from main.utils import get_request_view_name
 
 from product.models import Product
 
@@ -41,8 +41,8 @@ class ReviewSerializer(serializers.ModelSerializer):
         representation = super().to_representation(instance)
 
         # This is to check if the it is on the route `/api/v1/reviews/my-reviews/`
-        is_auth_user_reviews_route = self.context['request'].method == 'GET' and get_request_url_name(
-            self.context['request'].path) == 'my-reviews'
+        is_auth_user_reviews_route = get_request_view_name(
+            self.context['request'].path) == 'reviews:my-reviews'
 
         if is_auth_user_reviews_route:
             # If it is in the route `/api/v1/reviews/my-reviews/`, then remove

--- a/server/review/urls.py
+++ b/server/review/urls.py
@@ -3,8 +3,11 @@ from django.urls import path
 from . import views
 
 
+app_name = 'reviews'
+
 urlpatterns = [
-    path('', views.ReviewListCreateAPIView.as_view()),
-    path('<uuid:uuid>', views.ReviewDetailUpdateDeleteAPIView.as_view()),
+    path('', views.ReviewListCreateAPIView.as_view(), name='list-create'),
+    path('<uuid:uuid>', views.ReviewDetailUpdateDeleteAPIView.as_view(),
+         name='detail-update-delete'),
     path('my-reviews', views.ReviewListAPIView.as_view(), name='my-reviews'),
 ]

--- a/server/social/urls.py
+++ b/server/social/urls.py
@@ -3,9 +3,11 @@ from django.urls import path
 from . import views
 
 
+app_name = 'socials'
+
 urlpatterns = [
-    path('', views.LikeListCreateAPIView.as_view()),
-    path('<uuid:uuid>', views.LikeDetailAPIView.as_view()),
-    path('emojis/', views.EmojiListAPIView.as_view()),
-    path('emojis/<uuid:uuid>', views.EmojiDetailAPIView.as_view()),
+    path('', views.LikeListCreateAPIView.as_view(), name='list-create'),
+    path('<uuid:uuid>', views.LikeDetailAPIView.as_view(), name='detail'),
+    path('emojis/', views.EmojiListAPIView.as_view(), name='emoji-list'),
+    path('emojis/<uuid:uuid>', views.EmojiDetailAPIView.as_view(), name='emoji-detail'),
 ]

--- a/server/user/urls.py
+++ b/server/user/urls.py
@@ -3,9 +3,12 @@ from django.urls import path
 from . import views
 
 
+app_name = 'users'
+
 urlpatterns = [
-    path('register/', views.RegisterAPIView.as_view()),
-    path('login/', views.LoginAPIView.as_view()),
-    path('profile/', views.UserProfileRetrieveUpdateAPIView.as_view()),
-    path('change-password/', views.ChangePasswordUpdateAPIView.as_view()),
+    path('register/', views.RegisterAPIView.as_view(), name='register'),
+    path('login/', views.LoginAPIView.as_view(), name='login'),
+    path('profile/', views.UserProfileRetrieveUpdateAPIView.as_view(), name='profile'),
+    path('change-password/', views.ChangePasswordUpdateAPIView.as_view(),
+         name='change-password'),
 ]


### PR DESCRIPTION
## Changes
1. Created custom function called `get_request_view_name` which gets the name of the view that matches the URL.
2. Added to all apps URL namespaces to avoid conflicts between different views/serializers.
3. Removed the `truck` property from the JSON output to avoid redundancy on getting all products from the foodtruck's slug.

## Purpose
When going to the route on getting all products from a foodtruck's slug (`/api/v1/foodtrucks/<slug>/products`), the `truck` property should be removed from the JSON output to avoid redundancy since we already know what Foodtruck a particular product belongs to.

Closes #181 