### PR TITLE
Removed `product` From JSON Output on Getting All Reviews and Socials From Product

### DIFF
--- a/server/review/serializers.py
+++ b/server/review/serializers.py
@@ -9,7 +9,89 @@ from product.models import Product
 from user.models import CustomUser
 
 
-class ReviewSerializer(serializers.ModelSerializer):
+class ProductRepresentationModelSerializer(serializers.ModelSerializer):
+    """
+    A ModelSerializer that transforms the `product` field to return an object
+    for better description. In the `ReviewSerializer`, the fields (not the `fields`
+    in `Meta`) of `product` has a relational serializer field which is the
+    `SlugRelatedField`, and this would have an affect on the field to return the
+    `slug_field` parameter. This leads to less description. The solution is to
+    simply implement `to_representation` method for a better output description on
+    this field.
+    """
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        # Checks to see if the `image` field is not empty, or else it won't serialize.
+        product_image = None if not instance.product.image else instance.product.image
+
+        representation['product'] = {
+            'uuid': str(instance.product.uuid),
+            'name': instance.product.name,
+            'slug': instance.product.slug,
+            'image': product_image,
+        }
+
+        return representation
+
+
+class RemoveUserRepresentationSerializer(ProductRepresentationModelSerializer):
+    """
+    A RepresentationSerializer that removes the `user` field from the outout in
+    order to avoid redundancy since we already know what type of authenticated
+    user the list of reviews belongs to. This is known if the user is logged in
+    and enters the route: `/api/v1/reviews/my-reviews`.
+
+    If one wants to know the detail of this authenticated user, they simply call another
+    route: `/api/v1/users/profile`.
+
+    In other words, this route is only concern about getting all reviews from the
+    currently logged in authenticated user.
+
+    The route this only targets: `/api/v1/reviews/my-reviews`.
+    """
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        is_auth_user_reviews_route = get_request_view_name(
+            self.context['request'].path) == 'reviews:my-reviews'
+
+        if is_auth_user_reviews_route:
+            representation.pop('user')
+
+        return representation
+
+
+class RemoveProductRepresentationSerializer(RemoveUserRepresentationSerializer):
+    """
+    A RepresentationSerializer that removes the `product` field from the output in
+    order to avoid redundancy since we already know what type of product the list
+    of reviews belongs to. This is known by the product's slug from the nested route:
+    `/api/v1/products/<slug>/reviews`.
+
+    If one wants to know the detail of this product, they simply call another route:
+    `/api/v1/products/<slug>`.
+
+    In other words, this route is only concern about getting all reviews from the product.
+
+    The route this only targets: `/api/v1/products/<slug>/reviews`.
+    """
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        is_reviews_in_product_route = get_request_view_name(
+            self.context['request'].path) == 'products:review-list'
+
+        if is_reviews_in_product_route:
+            representation.pop('product')
+
+        return representation
+
+
+class ReviewSerializer(RemoveProductRepresentationSerializer):
     """
     Serializer on the Review model.
 
@@ -36,35 +118,3 @@ class ReviewSerializer(serializers.ModelSerializer):
         lookup_field = 'uuid'
         fields = ('uuid', 'review', 'created_at',
                   'updated_at', 'product', 'user',)
-
-    def to_representation(self, instance):
-        representation = super().to_representation(instance)
-
-        # This is to check if it is on the route `/api/v1/reviews/my-reviews/.`
-        is_auth_user_reviews_route = get_request_view_name(
-            self.context['request'].path) == 'reviews:my-reviews'
-
-        if is_auth_user_reviews_route:
-            # If it is in the route `/api/v1/reviews/my-reviews/`, then remove
-            # the `user` key since this route shows all reviews made by the
-            # current authenticated user (removes redundancy).
-            representation.pop('user')
-
-        # This is to check if it is on the route `/api/v1/products/<slug>/reviews/.`
-        is_reviews_in_product_route = get_request_view_name(
-            self.context['request'].path) == 'products:review-list'
-
-        if is_reviews_in_product_route:
-            representation.pop('product')
-        else:
-            # Checks to see if the `image` field is not empty, or else it won't serialize.
-            product_image = None if not instance.product.image else instance.product.image
-
-            representation['product'] = {
-                'uuid': str(instance.product.uuid),
-                'name': instance.product.name,
-                'slug': instance.product.slug,
-                'image': product_image,
-            }
-
-        return representation

--- a/server/review/serializers.py
+++ b/server/review/serializers.py
@@ -40,7 +40,7 @@ class ReviewSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         representation = super().to_representation(instance)
 
-        # This is to check if the it is on the route `/api/v1/reviews/my-reviews/`
+        # This is to check if it is on the route `/api/v1/reviews/my-reviews/.`
         is_auth_user_reviews_route = get_request_view_name(
             self.context['request'].path) == 'reviews:my-reviews'
 
@@ -50,14 +50,21 @@ class ReviewSerializer(serializers.ModelSerializer):
             # current authenticated user (removes redundancy).
             representation.pop('user')
 
-        # Checks to see if the `image` field is not empty, or else it won't serialize.
-        product_image = None if not instance.product.image else instance.product.image
+        # This is to check if it is on the route `/api/v1/products/<slug>/reviews/.`
+        is_reviews_in_product_route = get_request_view_name(
+            self.context['request'].path) == 'products:review-list'
 
-        representation['product'] = {
-            'uuid': str(instance.product.uuid),
-            'name': instance.product.name,
-            'slug': instance.product.slug,
-            'image': product_image,
-        }
+        if is_reviews_in_product_route:
+            representation.pop('product')
+        else:
+            # Checks to see if the `image` field is not empty, or else it won't serialize.
+            product_image = None if not instance.product.image else instance.product.image
+
+            representation['product'] = {
+                'uuid': str(instance.product.uuid),
+                'name': instance.product.name,
+                'slug': instance.product.slug,
+                'image': product_image,
+            }
 
         return representation

--- a/server/social/serializers.py
+++ b/server/social/serializers.py
@@ -47,6 +47,8 @@ class RemoveProductRepresentationSerializer(EmojiProductRepresentationModelSeria
     route: `/api/v1/products/<slug>`.
 
     In other words, this route is only concern about getting all socials from the product.
+
+    The route this only targets: `/api/v1/products/<slug>/socials`
     """
 
     def to_representation(self, instance):

--- a/server/social/serializers.py
+++ b/server/social/serializers.py
@@ -7,22 +7,19 @@ from main.utils import get_request_view_name
 from product.models import Product
 
 
-class LikeRepresentationModelSerializer(serializers.ModelSerializer):
+class EmojiProductRepresentationModelSerializer(serializers.ModelSerializer):
     """
     A ModelSerializer that transforms the `emoji` and `product` fields to return
     objects for better description. In the `LikeSerializer`, the fields (not the
     `fields` in `Meta`) of `emoji` and `product` have a relational serializer field
     which is the `SlugRelatedField`, and this would have an affect on both fields
     to return the `slug_field` parameter. This leads to less description. The
-    solution is to simply implement the `to_representation` method.
+    solution is to simply implement the `to_representation` method for a better
+    output description about these fields.
     """
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
-
-        # This is to check if it is on the route `/api/v1/products/<slug>/socials/`.
-        is_socials_in_product_route = get_request_view_name(
-            self.context['request'].path) == 'products:social-list'
 
         representation['emoji'] = {
             'uuid': instance.emoji.uuid,
@@ -30,17 +27,36 @@ class LikeRepresentationModelSerializer(serializers.ModelSerializer):
             'name': instance.emoji.name,
         }
 
+        representation['product'] = {
+            'uuid': instance.product.uuid,
+            'name': instance.product.name,
+            'slug': instance.product.slug,
+        }
+
+        return representation
+
+
+class RemoveProductRepresentationSerializer(EmojiProductRepresentationModelSerializer):
+    """
+    A RepresentationSerializer that removes the `product` field from the output in
+    order to avoid redundancy since we already know what type of product the list
+    of socials belongs to. This is known by the product's slug from the nested route:
+    `/api/v1/products/<slug>/socials`.
+
+    If one wants to know the detail of this product of this route, they simply call another
+    route: `/api/v1/products/<slug>`.
+
+    In other words, this route is only concern about getting all socials from the product.
+    """
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        is_socials_in_product_route = get_request_view_name(
+            self.context['request'].path) == 'products:social-list'
+
         if is_socials_in_product_route:
-            # If it is in the route `/api/v1/products/<slug>/products/`, then remove
-            # the `product` key since this route shows all the socials from the
-            # product (removes redundancy).
             representation.pop('product')
-        else:
-            representation['product'] = {
-                'uuid': instance.product.uuid,
-                'name': instance.product.name,
-                'slug': instance.product.slug,
-            }
 
         return representation
 
@@ -59,7 +75,7 @@ class EmojiSerializer(serializers.ModelSerializer):
         fields = ('uuid', 'emoji', 'name',)
 
 
-class LikeSerializer(LikeRepresentationModelSerializer):
+class LikeSerializer(RemoveProductRepresentationSerializer):
     """
     Serializer on the Like model.
 


### PR DESCRIPTION
## Changes
1. Removed the `product` property from the JSON output to avoid redundancy on getting all reviews from the product's slug, and from getting all socials from the product's slug.

## Purpose
When going to the route on getting all reviews from a product's slug (`/api/v1/products/<slug>/reviews/`), and on getting all socials from a product's slug (`/api/v1/products/<slug>/socials/`), the `product` property should be removed from the JSON output to avoid redundancy since we already know what Product a particular review and social belongs to.

Closes #182 