### PR TITLE
Extended the `truck` Field for the Event API

### DIFF
--- a/server/event/serializers.py
+++ b/server/event/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 
 from .models import Event
-from foodtruck.models import Truck
+
+from foodtruck.serializers import TruckSerializer
 
 
 class EventSerializer(serializers.ModelSerializer):
@@ -12,8 +13,8 @@ class EventSerializer(serializers.ModelSerializer):
 
     Fields: uuid, date, start_time, end_time, and truck.
     """
-    truck = serializers.SlugRelatedField(
-        slug_field='slug', queryset=Truck.objects.all(), many=True)
+    truck = TruckSerializer(
+        fields=('uuid', 'name', 'slug', 'images',), extra_fields=('profile_image',), many=True)
 
     class Meta:
         model = Event

--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -5,7 +5,7 @@ from .models import Truck, TruckImage
 from main.utils import DynamicFieldsModelSerializer
 
 
-class GetTruckProfileImageDynamicSerializer(DynamicFieldsModelSerializer):
+class TruckProfileImageDynamicSerializer(DynamicFieldsModelSerializer):
     """
     A DynamicSerializer that gets the Foodtruck's profile image.
 
@@ -32,7 +32,7 @@ class GetTruckProfileImageDynamicSerializer(DynamicFieldsModelSerializer):
         if extra_fields is not None and fields is not None:
             self.want_profile_image = 'profile_image' in extra_fields and 'images' in fields
 
-        super(GetTruckProfileImageDynamicSerializer,
+        super(TruckProfileImageDynamicSerializer,
               self).__init__(*args, **kwargs)
 
     def to_representation(self, instance):
@@ -72,7 +72,7 @@ class TruckImageSerializer(serializers.ModelSerializer):
         fields = ('uuid', 'image', 'is_profile_image', 'truck',)
 
 
-class TruckSerializer(GetTruckProfileImageDynamicSerializer):
+class TruckSerializer(TruckProfileImageDynamicSerializer):
     """
     Serializer on the Truck model. If the `profile_image` is required, then when
     initializing this serializer, add in `fields` with `images` and `extra_fields`


### PR DESCRIPTION
## Changes
1. Replaced the nested model relationship for the `truck` field in the `ProductSerializer` to use the `TruckSerializer` in order to change the JSON output for the `EventSerializer`.

## Purpose
The `truck` field for the Event API only returns an array of strings which are the foodtruck's slug. This should be changed and extended where the `truck` field returns an array of objects with keys of `name`, `slug`, `uuid`, and `profile_image` where the `profile_image` should only return the foodtruck's profile image.

Closes #169 
Closes #175 