### PR TITLE
Retrieved All Events From Foodtruck (Nested Route)

### DIFF
--- a/server/event/serializers.py
+++ b/server/event/serializers.py
@@ -1,11 +1,41 @@
 from rest_framework import serializers
 
+
 from .models import Event
 
 from foodtruck.serializers import TruckSerializer
 
+from main.utils import get_request_view_name
 
-class EventSerializer(serializers.ModelSerializer):
+
+class RemoveTruckRepresentationModelSerializer(serializers.ModelSerializer):
+    """
+    A ModelSerializer that removes the `truck` field from the output in order
+    to avoid redundancy since we already know what type of foodtruck the list of
+    events belongs to. This is known by the foodtruck's slug from the nested route:
+    `/api/v1/foodtrucks/<slug>/events`.
+
+    If one wants to know the detail of this foodtruck, they simply call another route:
+    `/api/v1/foodtrucks/<slug>`.
+
+    In other words, this route is only concern about getting all events from the foodtruck.
+
+    The route this only targets: `/api/v1/foodtrucks/<slug>/events`.
+    """
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        is_events_in_foodtruck_route = get_request_view_name(
+            self.context['request'].path) == 'foodtrucks:event-list'
+
+        if is_events_in_foodtruck_route:
+            representation.pop('truck')
+
+        return representation
+
+
+class EventSerializer(RemoveTruckRepresentationModelSerializer):
     """
     Serializer on the Event model.
 

--- a/server/foodtruck/urls.py
+++ b/server/foodtruck/urls.py
@@ -8,6 +8,8 @@ app_name = 'foodtrucks'
 urlpatterns = [
     path('', views.TruckListAPIView.as_view(), name='list'),
     path('<slug:slug>', views.TruckDetailAPIView.as_view(), name='detail'),
+    re_path(r'^(?P<truck_slug>[\w-]+)/events/?$',
+            views.TruckEventsModelViewSet.as_view({'get': 'list'}), name='event-list'),
     re_path(r'^(?P<truck_slug>[\w-]+)/products/?$',
             views.TruckProductsModelViewSet.as_view({'get': 'list'}), name='product-list'),
     re_path(r'^(?P<truck_slug>[\w-]+)/reviews/?$',


### PR DESCRIPTION
## Changes
1. Created a view and URL for a nested route on getting all events based on the foodtruck's slug so that developers/users could have more API options, and a solution on achieving this.
2. Created a custom serializer called `RemoveTruckRepresentationModelSerializer` to remove the `truck` property from the JSON output to avoid redundancy.

## Purpose
There should be an API call in the `foodtruck` app that calls all events based on the foodtruck's slug.

Closes #186 