### PR TITLE
Pagination for the API

### DIFF
--- a/server/main/pagination.py
+++ b/server/main/pagination.py
@@ -1,0 +1,10 @@
+from rest_framework import pagination
+
+
+class CustomPageNumberPagination(pagination.PageNumberPagination):
+    """
+    """
+    page_size = 1
+    page_size_query_param = 'count'
+    max_page_size = 100
+    page_query_param = 'p'

--- a/server/main/pagination.py
+++ b/server/main/pagination.py
@@ -15,7 +15,7 @@ class CustomPageNumberPagination(pagination.PageNumberPagination):
         return Response(OrderedDict([
             ('results', data),
             ('meta_data', OrderedDict([
-                ('count', self.page.paginator.count),
+                ('total_count', self.page.paginator.count),
                 ('next', self.get_next_link()),
                 ('previous', self.get_previous_link())
             ]))

--- a/server/main/pagination.py
+++ b/server/main/pagination.py
@@ -6,6 +6,17 @@ from rest_framework.response import Response
 
 class CustomPageNumberPagination(pagination.PageNumberPagination):
     """
+    A custom PageNumberPagination to be used for all API apps with a list of data.
+    If there is a list of data, the `meta_data` key would be inserted to the JSON output
+    that is an object with keys of `total_count` (total count of the list of data for all
+    pages), `next` (a hyperlink for the next result, or `None`), and `previous` (a hyperlink
+    for the previous result, or `None`. `None` for the initial start).
+
+    Default count per page: 10.
+
+    Query param to change the count per page: `count`.
+
+    Maximum amount of pages: 100.
     """
     page_size = 10
     page_size_query_param = 'count'

--- a/server/main/pagination.py
+++ b/server/main/pagination.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 class CustomPageNumberPagination(pagination.PageNumberPagination):
     """
     """
-    page_size = 1
+    page_size = 10
     page_size_query_param = 'count'
     max_page_size = 100
 

--- a/server/main/pagination.py
+++ b/server/main/pagination.py
@@ -10,7 +10,6 @@ class CustomPageNumberPagination(pagination.PageNumberPagination):
     page_size = 1
     page_size_query_param = 'count'
     max_page_size = 100
-    page_query_param = 'p'
 
     def get_paginated_response(self, data):
         return Response(OrderedDict([

--- a/server/main/pagination.py
+++ b/server/main/pagination.py
@@ -1,4 +1,7 @@
+from collections import OrderedDict
+
 from rest_framework import pagination
+from rest_framework.response import Response
 
 
 class CustomPageNumberPagination(pagination.PageNumberPagination):
@@ -8,3 +11,13 @@ class CustomPageNumberPagination(pagination.PageNumberPagination):
     page_size_query_param = 'count'
     max_page_size = 100
     page_query_param = 'p'
+
+    def get_paginated_response(self, data):
+        return Response(OrderedDict([
+            ('results', data),
+            ('meta_data', OrderedDict([
+                ('count', self.page.paginator.count),
+                ('next', self.get_next_link()),
+                ('previous', self.get_previous_link())
+            ]))
+        ]))

--- a/server/main/settings.py
+++ b/server/main/settings.py
@@ -155,6 +155,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'user.backends.JWTAuthentication',
     ),
+    'DEFAULT_PAGINATION_CLASS': 'main.pagination.CustomPageNumberPagination',
 }
 
 MEDIA_ROOT = BASE_DIR / 'media'

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -82,9 +82,7 @@ def error_404(request, exception):
     response = JsonResponse(data={
         'statusCode': 404,
         'status': 'fail',
-        'data': {
-            'message': 'The requested URL was not found on this server.',
-        },
+        'message': 'The requested URL was not found on this server.',
     })
 
     return response
@@ -94,9 +92,7 @@ def error_500(request):
     response = JsonResponse(data={
         'statusCode': 500,
         'status': 'error',
-        'data': {
-            'message': 'Sorry, a technical error has occured.',
-        },
+        'message': 'Sorry, a technical error has occured.',
     })
 
     return response

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -104,20 +104,18 @@ def error_500(request):
 
 def final_success_response(response):
     if not response.exception:
-        response_data = response.data
-
-        pagination_results = response.data.pop('results', None)
-        pagination_meta_data = response.data.pop('meta_data', None)
-
-        if pagination_results is not None and pagination_meta_data is not None:
-            response_data = pagination_results
-
         response.data = {
             'statusCode': response.status_code,
             'status': 'success',
-            'data': response_data,
-            'meta_data': pagination_meta_data,
+            'data': response.data,
         }
+
+        pagination_results = response.data['data'].pop('results', None)
+        pagination_meta_data = response.data['data'].pop('meta_data', None)
+
+        if pagination_results is not None and pagination_meta_data is not None:
+            response.data['data'] = pagination_results
+            response.data['meta_data'] = pagination_meta_data
 
 
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -104,10 +104,19 @@ def error_500(request):
 
 def final_success_response(response):
     if not response.exception:
+        response_data = response.data
+
+        pagination_results = response.data.pop('results', None)
+        pagination_meta_data = response.data.pop('meta_data', None)
+
+        if pagination_results is not None and pagination_meta_data is not None:
+            response_data = pagination_results
+
         response.data = {
             'statusCode': response.status_code,
             'status': 'success',
-            'data': response.data,
+            'data': response_data,
+            'meta_data': pagination_meta_data,
         }
 
 


### PR DESCRIPTION
## Changes
1. Created a custom pagination class for the REST API that uses hyperlinked pages for better user/developer experiences, and changing the JSON output for it with better description.
2. Expanded the JSON output when there is a success in the `final_success_response` function by checking if there is a pagination, and if it is then reformat the output by putting the pagination `results` property to `data` while inserting a `meta_data` property. This was done to keep a cleaner and useful JSON output for the user/developer.

## Purpose
There should be a pagination feature for the API so that the database is not overloaded when retrieving a ton of results, and so the users/developers would not receive a long unmanaged list that could slow their application.

Closes #189 