### PR TITLE
Remove `truck` out of JSON output for `TruckImageSerializer`

### DIFF
--- a/server/foodtruck/serializers.py
+++ b/server/foodtruck/serializers.py
@@ -62,14 +62,13 @@ class TruckImageSerializer(serializers.ModelSerializer):
 
     Lookup Field: slug.
 
-    Fields: uuid, image, is_profile_image, and truck.
+    Fields: uuid, image, and is_profile_image.
     """
-    truck = serializers.CharField(source='truck.slug')
 
     class Meta:
         model = TruckImage
         lookup_field = 'uuid'
-        fields = ('uuid', 'image', 'is_profile_image', 'truck',)
+        fields = ('uuid', 'image', 'is_profile_image',)
 
 
 class TruckSerializer(TruckProfileImageDynamicSerializer):


### PR DESCRIPTION
## Changes
1. Removed the `truck` property from the output inside the `image` object to avoid redundancy.

## Purpose
The `truck` property for the JSON output should not be seen when getting all foodtrucks even though it is which creates redundancy. This is from the `fact` that the fields in the `Meta` class from `TruckImageSerializer` has `truck`.

Closes #197 