### PR TITLE
Changed Any Camel Case from the Backend to Underscore for the JSON Output

### DIFF
--- a/server/main/exceptions.py
+++ b/server/main/exceptions.py
@@ -26,7 +26,7 @@ def custom_exception_handler(exc, context):
 
 def _handle_authentication_error(exc, context, response):
     response.data = {
-        'statusCode': response.status_code,
+        'status_code': response.status_code,
         'status': 'fail',
         'message': 'Please login to continue.',
     }
@@ -36,7 +36,7 @@ def _handle_authentication_error(exc, context, response):
 
 def _handle_generic_error(exc, context, response):
     response.data = {
-        'statusCode': response.status_code,
+        'status_code': response.status_code,
         'status': 'fail',
         'message': response.data['detail'],
     }
@@ -46,7 +46,7 @@ def _handle_generic_error(exc, context, response):
 
 def _handle_validation_error(exc, context, response):
     response.data = {
-        'statusCode': response.status_code,
+        'status_code': response.status_code,
         'status': 'fail',
         'message': 'Validation errors in your request.',
         'errors': response.data,

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -80,7 +80,7 @@ def slug_generator(sender, instance, *args, **kwargs):
 
 def error_404(request, exception):
     response = JsonResponse(data={
-        'statusCode': 404,
+        'status_code': 404,
         'status': 'fail',
         'message': 'The requested URL was not found on this server.',
     })
@@ -90,7 +90,7 @@ def error_404(request, exception):
 
 def error_500(request):
     response = JsonResponse(data={
-        'statusCode': 500,
+        'status_code': 500,
         'status': 'error',
         'message': 'Sorry, a technical error has occured.',
     })
@@ -101,7 +101,7 @@ def error_500(request):
 def final_success_response(response):
     if not response.exception:
         response.data = {
-            'statusCode': response.status_code,
+            'status_code': response.status_code,
             'status': 'success',
             'data': response.data,
         }


### PR DESCRIPTION
## Changes
1. Changed the JSON output for `statusCode` to be underscored and not camel case in order to keep all of the outputs consistent on how it looks.

## Purpose
Any of the properties (or keys) that are being sent as a camel case for the JSON output needs to be changed to an underscore so that everything can be consistent.

Closes #201 