### PR TITLE
Fixed Pagination Error (Server) and Changed the Delete API Responses for RTK TypeScript (Web)

### DIFF
--- a/server/event/views.py
+++ b/server/event/views.py
@@ -18,7 +18,7 @@ class EventListAPIView(generics.ListAPIView):
     queryset = Event.objects.all().order_by('date')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -37,6 +37,6 @@ class EventDetailAPIView(generics.RetrieveAPIView):
     lookup_field = 'uuid'
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)

--- a/server/foodtruck/views.py
+++ b/server/foodtruck/views.py
@@ -32,7 +32,7 @@ class TruckListAPIView(generics.ListAPIView):
     queryset = Truck.objects.all().order_by('name')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -51,7 +51,7 @@ class TruckDetailAPIView(generics.RetrieveAPIView):
     lookup_field = 'slug'
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -70,7 +70,7 @@ class TruckEventsModelViewSet(viewsets.ModelViewSet):
     queryset = Event.objects.all().prefetch_related('truck').order_by('date')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -99,7 +99,7 @@ class TruckProductsModelViewSet(viewsets.ModelViewSet):
     queryset = Product.objects.all().select_related('truck').order_by('slug')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -129,7 +129,7 @@ class TruckLikesModelViewSet(viewsets.ModelViewSet):
         'product').select_related('emoji').order_by('product__slug')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -159,7 +159,7 @@ class TruckReviewsModelViewSet(viewsets.ModelViewSet):
         'product').select_related('user').order_by('created_at')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -100,18 +100,25 @@ def error_500(request):
 
 def final_success_response(request, response):
     if not response.exception:
-        response.data = {
-            'status_code': response.status_code,
-            'status': 'success',
-            'data': response.data,
-        }
+        if request.method == 'DELETE':
+            response.data = {
+                'status_code': response.status_code,
+                'status': 'success',
+            }
 
-        if 'results' in response.data['data'] and 'meta_data' in response.data['data']:
-            pagination_results = response.data['data'].pop('results')
-            pagination_meta_data = response.data['data'].pop('meta_data')
+        else:
+            response.data = {
+                'status_code': response.status_code,
+                'status': 'success',
+                'data': response.data,
+            }
 
-            response.data['data'] = pagination_results
-            response.data['meta_data'] = pagination_meta_data
+            if 'results' in response.data['data'] and 'meta_data' in response.data['data']:
+                pagination_results = response.data['data'].pop('results')
+                pagination_meta_data = response.data['data'].pop('meta_data')
+
+                response.data['data'] = pagination_results
+                response.data['meta_data'] = pagination_meta_data
 
 
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -106,10 +106,10 @@ def final_success_response(response):
             'data': response.data,
         }
 
-        pagination_results = response.data['data'].pop('results', None)
-        pagination_meta_data = response.data['data'].pop('meta_data', None)
+        if 'results' in response.data['data'] and 'meta_data' in response.data['data']:
+            pagination_results = response.data['data'].pop('results')
+            pagination_meta_data = response.data['data'].pop('meta_data')
 
-        if pagination_results is not None and pagination_meta_data is not None:
             response.data['data'] = pagination_results
             response.data['meta_data'] = pagination_meta_data
 

--- a/server/main/utils.py
+++ b/server/main/utils.py
@@ -98,7 +98,7 @@ def error_500(request):
     return response
 
 
-def final_success_response(response):
+def final_success_response(request, response):
     if not response.exception:
         response.data = {
             'status_code': response.status_code,

--- a/server/product/views.py
+++ b/server/product/views.py
@@ -25,7 +25,7 @@ class ProductListAPIView(generics.ListAPIView):
     queryset = Product.objects.all().order_by('slug')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -44,7 +44,7 @@ class ProductDetailAPIView(generics.RetrieveAPIView):
     lookup_field = 'slug'
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -64,7 +64,7 @@ class ProductLikesModelViewSet(viewsets.ModelViewSet):
         'product').select_related('emoji').order_by('product__slug')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -94,7 +94,7 @@ class ProductReviewsModelViewSet(viewsets.ModelViewSet):
         'product').select_related('user').order_by('created_at')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 

--- a/server/review/views.py
+++ b/server/review/views.py
@@ -28,7 +28,7 @@ class ReviewListAPIView(generics.ListAPIView):
     queryset = Review.objects.all().order_by('created_at')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -50,7 +50,7 @@ class ReviewListCreateAPIView(generics.ListCreateAPIView):
     queryset = Review.objects.all().order_by('created_at')
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -71,6 +71,6 @@ class ReviewDetailUpdateDeleteAPIView(generics.RetrieveUpdateDestroyAPIView):
     lookup_field = 'uuid'
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)

--- a/server/social/views.py
+++ b/server/social/views.py
@@ -19,7 +19,7 @@ class EmojiListAPIView(generics.ListAPIView):
     queryset = Emoji.objects.all()
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -38,7 +38,7 @@ class EmojiDetailAPIView(generics.RetrieveAPIView):
     lookup_field = 'uuid'
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -56,7 +56,7 @@ class LikeListCreateAPIView(generics.ListCreateAPIView):
     queryset = Like.objects.all()
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -75,6 +75,6 @@ class LikeDetailAPIView(generics.RetrieveAPIView):
     lookup_field = 'uuid'
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)

--- a/server/user/views.py
+++ b/server/user/views.py
@@ -27,7 +27,7 @@ class ChangePasswordUpdateAPIView(UpdateAPIView):
     serializer_class = ChangePasswordSerializer
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -57,7 +57,7 @@ class LoginAPIView(APIView):
     serialzer_class = LoginSerializer
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -85,7 +85,7 @@ class RegisterAPIView(APIView):
     serializer_class = RegisterSerializer
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 
@@ -114,7 +114,7 @@ class UserProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
     serializer_class = UserProfileSerializer
 
     def finalize_response(self, request, response, *args, **kwargs):
-        final_success_response(response)
+        final_success_response(request, response)
 
         return super().finalize_response(request, response, *args, **kwargs)
 

--- a/web/src/common/api/foodtruckApi/reviewExtendedApi.ts
+++ b/web/src/common/api/foodtruckApi/reviewExtendedApi.ts
@@ -23,6 +23,8 @@ type GeneralReviewResponse = Omit<SuccessResponse, 'meta_data'> & {
   data: Review;
 };
 
+type DeleteReviewResponse = Omit<SuccessResponse, 'meta_data'>;
+
 const reviewExtendedApi = coreSplitApi.injectEndpoints({
   endpoints: (builder) => ({
     getReviews: builder.query<GetReviewsResponse, void>({
@@ -58,7 +60,7 @@ const reviewExtendedApi = coreSplitApi.injectEndpoints({
       invalidatesTags: ['Review'],
     }),
 
-    deleteReview: builder.mutation<void, string>({
+    deleteReview: builder.mutation<DeleteReviewResponse, string>({
       query: (uuid) => ({
         url: `/reviews/${uuid}`,
         method: 'DELETE',


### PR DESCRIPTION
## Changes
1. Server: Added a `request` to the parameter for `final_success_response` function to check if the request method is `DELETE` in order to change on how to send a response to the client.
2. Server: Changed the `if` conditional in `final_success_response` that now checks if the two keys exist in the dictionary instead of popping them out which could lead to errors (it's safer).
3. Web: Changed the response type for deleting reviews in the review extended API to keep consistent the response from the Backend.

## Purpose
When the user deletes their review, or performs any action, there should be no error from `final_success_response` when trying to implement pagination. Yet, somehow, when the user is deleting their review, there is an error from it.

Lastly, the response for the Backend on `DELETE` method has been changed where only the `status_code` and `status` are returned. Therefore, the TypeScript implementation for RTK needs to be reflected for this.

Closes #203 
Closes #204 